### PR TITLE
set threads as daemons

### DIFF
--- a/Smile/src/main/java/smile/util/MulticoreExecutor.java
+++ b/Smile/src/main/java/smile/util/MulticoreExecutor.java
@@ -58,7 +58,7 @@ public class MulticoreExecutor {
         }
         
         if (nprocs > 1) {
-            threads = (ThreadPoolExecutor) Executors.newFixedThreadPool(nprocs);
+            threads = (ThreadPoolExecutor) Executors.newFixedThreadPool(nprocs, new SimpleDeamonThreadFactory());
         }
     }
 

--- a/Smile/src/main/java/smile/util/SimpleDeamonThreadFactory.java
+++ b/Smile/src/main/java/smile/util/SimpleDeamonThreadFactory.java
@@ -1,0 +1,12 @@
+package smile.util; 
+
+
+import java.util.concurrent.ThreadFactory;
+
+class SimpleDeamonThreadFactory implements ThreadFactory {
+  public Thread newThread(Runnable r) {
+    Thread t = new Thread(r);
+    t.setDaemon(true);
+    return t;
+  }
+}


### PR DESCRIPTION
The threads created by the MulticoreExecutor prevented the JVM from exiting after the computation is finished. I use smile from scala using sbt, and this prevented the computation from exiting cleanly while leaving sbt running. I had to kill the JVM to terminate the program (including sbt which runs in the same JVM as the code). Setting the threads as daemons solved the problem.