### PR TITLE
Build was failing with maven 3.3.3 on JDK7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ doc/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+**/target

--- a/Smile/pom.xml
+++ b/Smile/pom.xml
@@ -42,6 +42,10 @@
         <developerConnection>scm:git:git@github.com:haifengl/smile.git</developerConnection>
         <url>git@github.com:haifengl/smile.git</url>
     </scm>
+    
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -77,6 +81,28 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+    
+    <profiles>
+        <profile>
+            <id>doclint-java8-disable</id>
+            
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -107,7 +133,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.2</version>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <!-- <additionalparam>-Xdoclint:none</additionalparam> -->
                 </configuration>
                 <executions>
                     <execution>

--- a/SmileData/pom.xml
+++ b/SmileData/pom.xml
@@ -42,6 +42,10 @@
         <developerConnection>scm:git:git@github.com:haifengl/smile.git</developerConnection>
         <url>git@github.com:haifengl/smile.git</url>
     </scm>
+    
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
       
     <dependencies>
         <dependency>
@@ -67,6 +71,28 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+    
+    <profiles>
+        <profile>
+            <id>doclint-java8-disable</id>
+            
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -97,7 +123,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.2</version>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <!-- <additionalparam>-Xdoclint:none</additionalparam> -->
                 </configuration>
                 <executions>
                     <execution>

--- a/SmileDemo/pom.xml
+++ b/SmileDemo/pom.xml
@@ -42,6 +42,10 @@
         <developerConnection>scm:git:git@github.com:haifengl/smile.git</developerConnection>
         <url>git@github.com:haifengl/smile.git</url>
     </scm>
+    
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -66,6 +70,28 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+    
+    <profiles>
+        <profile>
+            <id>doclint-java8-disable</id>
+            
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -107,7 +133,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.2</version>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <!-- <additionalparam>-Xdoclint:none</additionalparam> -->
                 </configuration>
                 <executions>
                     <execution>

--- a/SmileGraph/pom.xml
+++ b/SmileGraph/pom.xml
@@ -42,6 +42,10 @@
         <developerConnection>scm:git:git@github.com:haifengl/smile.git</developerConnection>
         <url>git@github.com:haifengl/smile.git</url>
     </scm>
+    
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -67,6 +71,28 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+    
+    <profiles>
+        <profile>
+            <id>doclint-java8-disable</id>
+            
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -97,7 +123,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.2</version>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <!-- <additionalparam>-Xdoclint:none</additionalparam> -->
                 </configuration>
                 <executions>
                     <execution>

--- a/SmileInterpolation/pom.xml
+++ b/SmileInterpolation/pom.xml
@@ -42,6 +42,10 @@
         <developerConnection>scm:git:git@github.com:haifengl/smile.git</developerConnection>
         <url>git@github.com:haifengl/smile.git</url>
     </scm>
+    
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -67,6 +71,28 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+    
+    <profiles>
+        <profile>
+            <id>doclint-java8-disable</id>
+            
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -97,7 +123,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.2</version>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <!-- <additionalparam>-Xdoclint:none</additionalparam> -->
                 </configuration>
                 <executions>
                     <execution>

--- a/SmileMath/pom.xml
+++ b/SmileMath/pom.xml
@@ -42,6 +42,10 @@
         <developerConnection>scm:git:git@github.com:haifengl/smile.git</developerConnection>
         <url>git@github.com:haifengl/smile.git</url>
     </scm>
+    
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -62,6 +66,28 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+    
+    <profiles>
+        <profile>
+            <id>doclint-java8-disable</id>
+            
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -92,7 +118,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.2</version>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <!-- <additionalparam>-Xdoclint:none</additionalparam> -->
                 </configuration>
                 <executions>
                     <execution>

--- a/SmileNLP/pom.xml
+++ b/SmileNLP/pom.xml
@@ -42,6 +42,10 @@
         <developerConnection>scm:git:git@github.com:haifengl/smile.git</developerConnection>
         <url>git@github.com:haifengl/smile.git</url>
     </scm>
+    
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -72,6 +76,28 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+    
+    <profiles>
+        <profile>
+            <id>doclint-java8-disable</id>
+            
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -102,7 +128,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.2</version>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <!-- <additionalparam>-Xdoclint:none</additionalparam> -->
                 </configuration>
                 <executions>
                     <execution>

--- a/SmilePlot/pom.xml
+++ b/SmilePlot/pom.xml
@@ -42,6 +42,10 @@
         <developerConnection>scm:git:git@github.com:haifengl/smile.git</developerConnection>
         <url>git@github.com:haifengl/smile.git</url>
     </scm>
+    
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -71,6 +75,28 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+    
+    <profiles>
+        <profile>
+            <id>doclint-java8-disable</id>
+            
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -101,7 +127,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.2</version>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <!-- <additionalparam>-Xdoclint:none</additionalparam> -->
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
         <module>SmilePlot</module>
     </modules>
     
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
@@ -63,6 +67,28 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+    
+    <profiles>
+        <profile>
+            <id>doclint-java8-disable</id>
+            
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <build>
         <pluginManagement>
@@ -86,6 +112,9 @@
                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
                     </configuration>
                 </plugin>
+                
+                
+                
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
The reason was -Xdoclint:none specified in javadoc plugin was not recognized.
The problem should be solved by adding a profile which only adds the switch if JDK >= 1.8 is detected.

Also added /target directories to .gitignore.