### PR TITLE
Change library versions to numbers that actually exist in Sonatype.

### DIFF
--- a/shell/src/universal/doc/faq.html
+++ b/shell/src/universal/doc/faq.html
@@ -20,21 +20,21 @@
     <h1 id="top" class="title">Smile FAQ</h1>
     <h2 class="question" id="link-with-smile">Link with Smile</h2>
     <p class="answer">
-        Smile artifacts are hosted in <a href="https://oss.sonatype.org/#nexus-search;quick~smile-core">Sonatgype Nexus</a>.
+        Smile artifacts are hosted in <a href="https://oss.sonatype.org/#nexus-search;quick~smile-core">Sonatype Nexus</a>.
         You can add the following dependency into your pom.xml:</p>
 
     <pre><code>
     &lt;dependency&gt;
       &lt;groupId&gt;com.github.haifengl&lt;/groupId&gt;
       &lt;artifactId&gt;smile-core&lt;/artifactId&gt;
-      &lt;version&gt;1.1.0&lt;/version&gt;
+      &lt;version&gt;1.0.4&lt;/version&gt;
     &lt;/dependency&gt;
     </code></pre>
 
     <p>If you're using SBT, add the following line into your build file:</p>
 
     <pre><code>
-    libraryDependencies += "com.github.haifengl" % "smile-core" % "1.1.0"
+    libraryDependencies += "com.github.haifengl" % "smile-core" % "1.0.4"
     </code></pre>
 
     <h2 class="question" id="model-serialization">Model serialization</h2>


### PR DESCRIPTION
The SBT command as written doesn't work.  Based on the Sonatype link it seems like the highest version is actually 1.0.4, instead of 1.1.0.

Note that I don't use Maven so I haven't tested that change, but the SBT dependency appears to work now.