### PR TITLE
Make Simple and PennTreebank tokenizers Unicode-aware

### DIFF
--- a/nlp/src/main/java/smile/nlp/tokenizer/PennTreebankTokenizer.java
+++ b/nlp/src/main/java/smile/nlp/tokenizer/PennTreebankTokenizer.java
@@ -68,7 +68,7 @@ public class PennTreebankTokenizer implements Tokenizer {
 
     private static final Pattern[] DELIMITERS = {
         // Separate most punctuation
-        Pattern.compile("([^\\w\\.\\'\\-\\/,&])"),
+        Pattern.compile("([^\\p{L}\\p{N}\\p{M}\\p{Sk}\u200C\u200D\\.\\'\\-\\/,&])"),
         // Separate commas if they're followed by space (e.g., don't separate 2,500)
         Pattern.compile("(,\\s)"),
         // Separate single quotes if they're followed by a space.

--- a/nlp/src/main/java/smile/nlp/tokenizer/SimpleTokenizer.java
+++ b/nlp/src/main/java/smile/nlp/tokenizer/SimpleTokenizer.java
@@ -85,7 +85,7 @@ public class SimpleTokenizer implements Tokenizer {
 
     private static final Pattern[] DELIMITERS = {
         // Separate most punctuation
-        Pattern.compile("([^\\w\\.\\'\\-\\/,&])"),
+        Pattern.compile("([^\\p{L}\\p{N}\\p{M}\\p{Sk}‌‍‌‍‌‍‌‍\u200C\u200D\\.\\'\\-\\/,&])"),
         // Separate commas if they're followed by space (e.g., don't separate 2,500)
         Pattern.compile("(,\\s)"),
         // Separate single quotes if they're followed by a space.

--- a/nlp/src/test/java/smile/nlp/tokenizer/PennTreebankTokenizerTest.java
+++ b/nlp/src/test/java/smile/nlp/tokenizer/PennTreebankTokenizerTest.java
@@ -227,4 +227,64 @@ public class PennTreebankTokenizerTest {
             assertEquals(expResult[i], result[i]);
         }
     }
+
+    /**
+     * Test of split method, of class TreebankWordTokenizer.
+     */
+    @Test
+    public void testTokenizeMixedAlphanumWords() {
+        System.out.println("tokenize words with mixed numbers, letters, and punctuation");
+        String text = "3M, L-3, BB&T, AutoZone, O'Reilly, Harley-Davidson, CH2M, A-Mark, "
+            + "Quad/Graphics, Bloomin' Brands, B/E Aerospace, J.Crew, E*Trade.";
+
+        // Note: would be very hard to get "Bloomin'" and "E*Trade" correct
+        String[] expResult = {"3M", ",", "L-3", ",", "BB&T", ",", "AutoZone", ",", "O'Reilly",
+            ",", "Harley-Davidson", ",", "CH2M", ",", "A-Mark", ",", "Quad/Graphics", ",", "Bloomin",
+            "'", "Brands", ",", "B/E", "Aerospace", ",", "J.Crew", ",", "E", "*", "Trade", "."};
+
+        SimpleTokenizer instance = new SimpleTokenizer();
+        String[] result = instance.split(text);
+
+        assertEquals(expResult.length, result.length);
+        for (int i = 0; i < result.length; i++) {
+            assertEquals(expResult[i], result[i]);
+        }
+    }
+
+    /**
+     * Test of split method, of class TreebankWordTokenizer.
+     */
+    @Test
+    public void testTokenizeDiacritizedWords() {
+        System.out.println("tokenize words with diacritized chars (both composite and combining)");
+        String text = "The naïve résumé of Raúl Ibáñez; re\u0301sume\u0301.";
+        String[] expResult = {"The", "naïve", "résumé", "of", "Raúl", "Ibáñez", ";", "re\u0301sume\u0301", "."};
+
+        SimpleTokenizer instance = new SimpleTokenizer();
+        String[] result = instance.split(text);
+
+        //assertEquals(expResult.length, result.length);
+        for (int i = 0; i < result.length; i++) {
+            assertEquals(expResult[i], result[i]);
+        }
+    }
+
+    /**
+     * Test of split method, of class TreebankWordTokenizer.
+     */
+    @Test
+    public void testTokenizeNonLatinChars() {
+        System.out.println("tokenize words containing non-Latin chars");
+        // See https://en.wikipedia.org/wiki/Zero-width_non-joiner
+        String text = "می‌خواهم   עֲו‌ֹנֹת   Auf‌lage";
+        String[] expResult = {"می‌خواهم", "עֲו‌ֹנֹת", "Auf‌lage"};
+
+        SimpleTokenizer instance = new SimpleTokenizer();
+        String[] result = instance.split(text);
+
+        assertEquals(expResult.length, result.length);
+        for (int i = 0; i < result.length; i++) {
+            assertEquals(expResult[i], result[i]);
+        }
+    }
 }

--- a/nlp/src/test/java/smile/nlp/tokenizer/SimpleTokenizerTest.java
+++ b/nlp/src/test/java/smile/nlp/tokenizer/SimpleTokenizerTest.java
@@ -227,4 +227,64 @@ public class SimpleTokenizerTest {
             assertEquals(expResult[i], result[i]);
         }
     }
+
+    /**
+     * Test of split method, of class SimpleTokenizer.
+     */
+    @Test
+    public void testTokenizeMixedAlphanumWords() {
+        System.out.println("tokenize words with mixed numbers, letters, and punctuation");
+        String text = "3M, L-3, BB&T, AutoZone, O'Reilly, Harley-Davidson, CH2M, A-Mark, "
+                + "Quad/Graphics, Bloomin' Brands, B/E Aerospace, J.Crew, E*Trade.";
+
+        // Note: would be very hard to get "Bloomin'" and "E*Trade" correct
+        String[] expResult = {"3M", ",", "L-3", ",", "BB&T", ",", "AutoZone", ",", "O'Reilly",
+                ",", "Harley-Davidson", ",", "CH2M", ",", "A-Mark", ",", "Quad/Graphics", ",", "Bloomin",
+                "'", "Brands", ",", "B/E", "Aerospace", ",", "J.Crew", ",", "E", "*", "Trade", "."};
+
+        SimpleTokenizer instance = new SimpleTokenizer();
+        String[] result = instance.split(text);
+
+        assertEquals(expResult.length, result.length);
+        for (int i = 0; i < result.length; i++) {
+            assertEquals(expResult[i], result[i]);
+        }
+    }
+
+    /**
+     * Test of split method, of class SimpleTokenizer.
+     */
+    @Test
+    public void testTokenizeDiacritizedWords() {
+        System.out.println("tokenize words with diacritized chars (both composite and combining)");
+        String text = "The naïve résumé of Raúl Ibáñez; re\u0301sume\u0301.";
+        String[] expResult = {"The", "naïve", "résumé", "of", "Raúl", "Ibáñez", ";", "re\u0301sume\u0301", "."};
+
+        SimpleTokenizer instance = new SimpleTokenizer();
+        String[] result = instance.split(text);
+
+        assertEquals(expResult.length, result.length);
+        for (int i = 0; i < result.length; i++) {
+            assertEquals(expResult[i], result[i]);
+        }
+    }
+
+    /**
+     * Test of split method, of class TreebankWordTokenizer.
+     */
+    @Test
+    public void testTokenizeNonLatinChars() {
+        System.out.println("tokenize words containing non-Latin chars");
+        // See https://en.wikipedia.org/wiki/Zero-width_non-joiner
+        String text = "می‌خواهم   עֲו‌ֹנֹת   Auf‌lage";
+        String[] expResult = {"می‌خواهم", "עֲו‌ֹנֹת", "Auf‌lage"};
+
+        SimpleTokenizer instance = new SimpleTokenizer();
+        String[] result = instance.split(text);
+
+        assertEquals(expResult.length, result.length);
+        for (int i = 0; i < result.length; i++) {
+            assertEquals(expResult[i], result[i]);
+        }
+    }
 }


### PR DESCRIPTION
Hi Haifeng,
The SimpleTokenizer and PennTreebankTokenizer rely on the regex character class `\w` in the first delimiter pattern. Unfortunately, `\w` only matches the ASCII letters and numbers, so words with diacritized characters or non-Latin characters are not recognized as tokens. For example, `résumé` is tokenized as `["r", "é", "sum", "é"]`. 

I replaced `\w` with the following: `\p{L}\p{N}\p{M}\p{Sk}\u200C\u200D`. This expression matches the unicode letter category (L), the number category (N), the marks category (M, which includes combining diacritics), some miscellaneous diacritics (Sk), and the zero-width non-joiner and joiner characters (used word-internally mostly in Arabic script but sometimes in other languages).

These changes should improve tokenization on English and European languages, as well as providing a decent baseline tokenization for non-Western whitespace-delimited languages.