### PR TITLE
Use the UNICODE_CHARACTER_CLASS flag (?U) for both \s and \w in token…

### DIFF
--- a/nlp/src/main/java/smile/nlp/tokenizer/PennTreebankTokenizer.java
+++ b/nlp/src/main/java/smile/nlp/tokenizer/PennTreebankTokenizer.java
@@ -68,16 +68,16 @@ public class PennTreebankTokenizer implements Tokenizer {
 
     private static final Pattern[] DELIMITERS = {
         // Separate most punctuation
-        Pattern.compile("([^\\p{L}\\p{N}\\p{M}\\p{Sk}\u200C\u200D\\.\\'\\-\\/,&])"),
+        Pattern.compile("(?U)([^\\w\\.\\'\\-\\/,&])"),
         // Separate commas if they're followed by space (e.g., don't separate 2,500)
-        Pattern.compile("(,\\s)"),
+        Pattern.compile("(?U)(,\\s)"),
         // Separate single quotes if they're followed by a space.
-        Pattern.compile("('\\s)"),
+        Pattern.compile("(?U)('\\s)"),
         // Separate periods that come before newline or end of string.
-        Pattern.compile("\\. *(\\n|$)")
+        Pattern.compile("(?U)\\. *(\\n|$)")
     };
 
-    private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+    private static final Pattern WHITESPACE = Pattern.compile("(?U)\\s+");
 
     /**
      * The singleton instance.

--- a/nlp/src/main/java/smile/nlp/tokenizer/SimpleTokenizer.java
+++ b/nlp/src/main/java/smile/nlp/tokenizer/SimpleTokenizer.java
@@ -85,16 +85,16 @@ public class SimpleTokenizer implements Tokenizer {
 
     private static final Pattern[] DELIMITERS = {
         // Separate most punctuation
-        Pattern.compile("([^\\p{L}\\p{N}\\p{M}\\p{Sk}‌‍‌‍‌‍‌‍\u200C\u200D\\.\\'\\-\\/,&])"),
+        Pattern.compile("((?U)[^\\w\\.\\'\\-\\/,&])"),
         // Separate commas if they're followed by space (e.g., don't separate 2,500)
-        Pattern.compile("(,\\s)"),
+        Pattern.compile("(?U)(,\\s)"),
         // Separate single quotes if they're followed by a space.
-        Pattern.compile("('\\s)"),
+        Pattern.compile("(?U)('\\s)"),
         // Separate periods that come before newline or end of string.
-        Pattern.compile("\\. *(\\n|$)")
+        Pattern.compile("(?U)\\. *(\\n|$)")
     };
 
-    private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+    private static final Pattern WHITESPACE = Pattern.compile("(?U)\\s+");
 
     private boolean splitContraction;
     /**

--- a/nlp/src/test/java/smile/nlp/tokenizer/PennTreebankTokenizerTest.java
+++ b/nlp/src/test/java/smile/nlp/tokenizer/PennTreebankTokenizerTest.java
@@ -287,4 +287,23 @@ public class PennTreebankTokenizerTest {
             assertEquals(expResult[i], result[i]);
         }
     }
+
+    /**
+     * Test of split method, of class TreebankWordTokenizer.
+     */
+    @Test
+    public void testTokenizeVariousSpaces() {
+        System.out.println("tokenize words separated by various kinds of space");
+        // No-break space and em-space
+        String text = "the\u00A0cat\u2003the_cat";
+        String[] expResult = {"the", "cat", "the_cat"};
+
+        SimpleTokenizer instance = new SimpleTokenizer();
+        String[] result = instance.split(text);
+
+        assertEquals(expResult.length, result.length);
+        for (int i = 0; i < result.length; i++) {
+            assertEquals(expResult[i], result[i]);
+        }
+    }
 }

--- a/nlp/src/test/java/smile/nlp/tokenizer/SimpleTokenizerTest.java
+++ b/nlp/src/test/java/smile/nlp/tokenizer/SimpleTokenizerTest.java
@@ -287,4 +287,24 @@ public class SimpleTokenizerTest {
             assertEquals(expResult[i], result[i]);
         }
     }
+
+    /**
+     * Test of split method, of class TreebankWordTokenizer.
+     */
+    @Test
+    public void testTokenizeVariousSpaces() {
+        System.out.println("tokenize words separated by various kinds of space");
+        // No-break space and em-space
+        String text = "the\u00A0cat\u2003the_cat";
+        String[] expResult = {"the", "cat", "the_cat"};
+
+        SimpleTokenizer instance = new SimpleTokenizer();
+        String[] result = instance.split(text);
+
+        assertEquals(expResult.length, result.length);
+        for (int i = 0; i < result.length; i++) {
+            assertEquals(expResult[i], result[i]);
+        }
+    }
+
 }


### PR DESCRIPTION
I ran into another issue with the tokenizers: not recognizing non-ascii space chars such as the no-break space (often found in web pages) and em-space. I believe the more general (and correct) solution is to simply enable the UNICODE_CHARACTER_CLASS flag on the tokenizer regexes. This also simplifies the previous change since `\w` will just do the right thing now.