### PR TITLE
Text normalization

### DIFF
--- a/nlp/src/main/java/smile/nlp/normalizer/Normalizer.java
+++ b/nlp/src/main/java/smile/nlp/normalizer/Normalizer.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2010 Haifeng Li
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package smile.nlp.normalizer;
+
+/**
+ * Normalization transforms text into a canonical form by removing unwanted
+ * variations. Normalization may range from light textual cleanup such as
+ * compressing whitespace to more aggressive and knowledge-intensive forms
+ * like standardizing date formats or expanding abbreviations. The nature and
+ * extent of normalization, as well as whether it is most appropriate to apply
+ * on the document, sentence, or token level, must be determined in the context
+ * of a specific application.
+ *
+ * @author Mark Arehart
+ */
+public interface Normalizer {
+
+    /**
+     * Normalize the given string.
+     */
+    public String normalize(String text);
+}

--- a/nlp/src/main/java/smile/nlp/normalizer/SimpleNormalizer.java
+++ b/nlp/src/main/java/smile/nlp/normalizer/SimpleNormalizer.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2010 Haifeng Li
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package smile.nlp.normalizer;
+
+import java.util.regex.Pattern;
+
+/**
+ * A baseline normalizer for processing Unicode text:
+ * <ul>
+ * <li>Apply Unicode normalization form NFKC.</li>
+ * <li>Strip, trim, normalize, and compress whitespace.</li>
+ * <li>Remove control and formatting characters.</li>
+ * <li>Normalize greater-than and less-than signs, double and single quotes, and dashes.</li>
+ * </ul>
+ *
+ * @author Mark Arehart
+ */
+public class SimpleNormalizer implements Normalizer {
+
+    private static final Pattern WHITESPACE = Pattern.compile("(?U)\\s+");
+
+    private static final Pattern CONTROL_FORMAT_CHARS = Pattern.compile("[\\p{Cc}\\p{Cf}]");
+
+    private static final Pattern LT_SIGNS = Pattern.compile("[\\u003C\\u2039\\u2329\\u276E\\u3008]");
+
+    private static final Pattern GT_SIGNS = Pattern.compile("[\\u003E\\u203A\\u232A\\u276F\\u3009]");
+
+    private static final Pattern DOUBLE_QUOTES = Pattern.compile("\\u0022\\u02BA\\u201C\\u201D\\u201E\\u201F\\u2033\\u2036\\u275D\\u275E\\u301D\\u301E\\u301F\\uFF02");
+
+    private static final Pattern SINGLE_QUOTES = Pattern.compile("[\\u0060\\u0027\\u02BB\\u02BC\\u02BD\\u2018\\u2019\\u201A\\u201B\\u275B\\u275C]");
+
+    private static final Pattern DASHES = Pattern.compile("[\\u002D\\u2012\\u2013\\u2014\\u2015\\uFE58\\uFE31\\uFE32]");
+
+    /**
+     * The singleton instance.
+     */
+    private static SimpleNormalizer singleton = new SimpleNormalizer();
+
+    /**
+     * Constructor.
+     */
+    private SimpleNormalizer() { }
+
+    /**
+     * Returns the singleton instance.
+     */
+    public static SimpleNormalizer getInstance() {
+        return singleton;
+    }
+
+    @Override
+    public String normalize(String text) {
+
+        text = text.trim();
+        text = java.text.Normalizer.normalize(text, java.text.Normalizer.Form.NFKC);
+        text = WHITESPACE.matcher(text).replaceAll(" ");
+        text = CONTROL_FORMAT_CHARS.matcher(text).replaceAll("");
+        text = LT_SIGNS.matcher(text).replaceAll("<");
+        text = GT_SIGNS.matcher(text).replaceAll(">");
+        text = DOUBLE_QUOTES.matcher(text).replaceAll("\"");
+        text = SINGLE_QUOTES.matcher(text).replaceAll("'");
+        text = DASHES.matcher(text).replaceAll("-");
+        return text;
+    }
+}

--- a/nlp/src/main/java/smile/nlp/normalizer/SimpleNormalizer.java
+++ b/nlp/src/main/java/smile/nlp/normalizer/SimpleNormalizer.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
  * <li>Apply Unicode normalization form NFKC.</li>
  * <li>Strip, trim, normalize, and compress whitespace.</li>
  * <li>Remove control and formatting characters.</li>
- * <li>Normalize greater-than and less-than signs, double and single quotes, and dashes.</li>
+ * <li>Normalize double and single quotes.</li>
  * </ul>
  *
  * @author Mark Arehart
@@ -35,15 +35,9 @@ public class SimpleNormalizer implements Normalizer {
 
     private static final Pattern CONTROL_FORMAT_CHARS = Pattern.compile("[\\p{Cc}\\p{Cf}]");
 
-    private static final Pattern LT_SIGNS = Pattern.compile("[\\u003C\\u2039\\u2329\\u276E\\u3008]");
+    private static final Pattern DOUBLE_QUOTES = Pattern.compile("[\\u02BA\\u201C\\u201D\\u201E\\u201F\\u2033\\u2036\\u275D\\u275E\\u301D\\u301E\\u301F\\uFF02]");
 
-    private static final Pattern GT_SIGNS = Pattern.compile("[\\u003E\\u203A\\u232A\\u276F\\u3009]");
-
-    private static final Pattern DOUBLE_QUOTES = Pattern.compile("\\u0022\\u02BA\\u201C\\u201D\\u201E\\u201F\\u2033\\u2036\\u275D\\u275E\\u301D\\u301E\\u301F\\uFF02");
-
-    private static final Pattern SINGLE_QUOTES = Pattern.compile("[\\u0060\\u0027\\u02BB\\u02BC\\u02BD\\u2018\\u2019\\u201A\\u201B\\u275B\\u275C]");
-
-    private static final Pattern DASHES = Pattern.compile("[\\u002D\\u2012\\u2013\\u2014\\u2015\\uFE58\\uFE31\\uFE32]");
+    private static final Pattern SINGLE_QUOTES = Pattern.compile("[\\u0060\\u02BB\\u02BC\\u02BD\\u2018\\u2019\\u201A\\u201B\\u275B\\u275C]");
 
     /**
      * The singleton instance.
@@ -66,14 +60,19 @@ public class SimpleNormalizer implements Normalizer {
     public String normalize(String text) {
 
         text = text.trim();
-        text = java.text.Normalizer.normalize(text, java.text.Normalizer.Form.NFKC);
+
+        if (!java.text.Normalizer.isNormalized(text, java.text.Normalizer.Form.NFKC)) {
+            text = java.text.Normalizer.normalize(text, java.text.Normalizer.Form.NFKC);
+        }
+
         text = WHITESPACE.matcher(text).replaceAll(" ");
+
         text = CONTROL_FORMAT_CHARS.matcher(text).replaceAll("");
-        text = LT_SIGNS.matcher(text).replaceAll("<");
-        text = GT_SIGNS.matcher(text).replaceAll(">");
+
         text = DOUBLE_QUOTES.matcher(text).replaceAll("\"");
+
         text = SINGLE_QUOTES.matcher(text).replaceAll("'");
-        text = DASHES.matcher(text).replaceAll("-");
+
         return text;
     }
 }

--- a/nlp/src/test/java/smile/nlp/normalizer/SimpleNormalizerTest.java
+++ b/nlp/src/test/java/smile/nlp/normalizer/SimpleNormalizerTest.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2010 Haifeng Li
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package smile.nlp.normalizer;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Mark Arehart
+ */
+public class SimpleNormalizerTest {
+
+    /**
+     * Test of normalize method, of class SimpleNormalizer.
+     */
+    @Test
+    public void testSplit() {
+        System.out.println("normalize text");
+        String text = "\tTHE BIG RIPOFF\n\n"
+                + "Mr. John B. Smith bought cheapsite.com for 1.5 million dollars,\n\r"
+                + "i.e. he paid far too much for it.\n\n"
+                + "Did he mind?\n\r"
+                + "   \t     \n"
+                + "Adam Jones Jr. thinks \u201Che\u0301\u201D didn\u2019t.    \n\r\n"
+                + "......\n"
+                + "In any case, this isn't true... Well, with a probability of .9 it isn't. ";
+
+        String expected = "THE BIG RIPOFF "
+                + "Mr. John B. Smith bought cheapsite.com for 1.5 million dollars, "
+                + "i.e. he paid far too much for it. "
+                + "Did he mind? "
+                + "Adam Jones Jr. thinks \"hé\" didn't. "
+                + "...... "
+                + "In any case, this isn't true... Well, with a probability of .9 it isn't.";
+
+        String result = SimpleNormalizer.getInstance().normalize(text);
+
+        assertEquals(expected, result);
+    }
+}

--- a/nlp/src/test/java/smile/nlp/tokenizer/SimpleSentenceSplitterTest.java
+++ b/nlp/src/test/java/smile/nlp/tokenizer/SimpleSentenceSplitterTest.java
@@ -85,4 +85,42 @@ public class SimpleSentenceSplitterTest {
         for (int i = 0; i < result.length; i++)
             assertEquals(expResult[i], result[i]);
     }
+
+    /**
+     * Test of split method, of class SimpleSentenceSplitter.
+     */
+    @Test
+    public void testSplitUnicode() {
+        System.out.println("split with unicode chars");
+        String text = "THE BIG RIPOFF\n\n"
+                + "Mr. John B. Smith bought www.cheap.com for 1.5 million dollars, "
+                + "i.e. he paid far too much for it.Did he mind? "
+                + "Adam Jones Jr. thinks he didn't. In any case, this isn't true..."
+                + "Well, it isn't with a probability of .9.Right?"
+                + "Again, it isn't with a probability of .9 .Right?"
+                + "[This is bracketed sentence.] "
+                + "\"This is quoted sentence.\" "
+                + "This last sentence has no period";
+
+        String[] expResult = {
+                "THE BIG RIPOFF Mr. John B. Smith bought www.cheap.com for 1.5 million dollars, i.e. he paid far too much for it.",
+                "Did he mind?",
+                "Adam Jones Jr. thinks he didn't.",
+                "In any case, this isn't true...",
+                "Well, it isn't with a probability of .9.",
+                "Right?",
+                "Again, it isn't with a probability of .9.",
+                "Right?",
+                "[This is bracketed sentence.]",
+                "\"This is quoted sentence.\"",
+                "This last sentence has no period"
+        };
+
+        SimpleSentenceSplitter instance = SimpleSentenceSplitter.getInstance();
+        String[] result = instance.split(text);
+
+        assertEquals(expResult.length, result.length);
+        for (int i = 0; i < result.length; i++)
+            assertEquals(expResult[i], result[i]);
+    }
 }


### PR DESCRIPTION
Haifeng,
While using Smile's tokenizer and pos-tagger, I came across a need to perform basic text normalization. I added a normalization interface and a simple normalizer that applies the Unicode normalization form NFKC, trims/compresses/normalizes whitespace, removes formatting and control characters, and replaces non-ASCII double and single quotes (i.e. "curly quotes") with their ASCII versions. I hope others might find it useful.