### PR TITLE
Fix: squid:S1210, "equals(Object obj)" should be overridden along wit…

### DIFF
--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -409,6 +409,26 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
             return (int) Math.signum(a.node.splitScore - node.splitScore);
         }
 
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null) {
+                return true;
+            }
+            if (obj instanceof TrainNode) {
+                return this.node.splitFeature == ((TrainNode)obj).node.splitScore;
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            long fitnessLong = Double.doubleToLongBits(node.splitScore);
+            return 41 + (int) (fitnessLong ^ (fitnessLong >>> 32));
+        }
+
         /**
          * Task to find the best split cutoff for attribute j at the current node.
          */

--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -15,19 +15,19 @@
  *******************************************************************************/
 package smile.classification;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.PriorityQueue;
-import java.util.concurrent.Callable;
-
 import smile.data.Attribute;
 import smile.data.NominalAttribute;
 import smile.data.NumericAttribute;
 import smile.math.Math;
 import smile.sort.QuickSort;
 import smile.util.MulticoreExecutor;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.concurrent.Callable;
 
 /**
  * Decision tree for classification. A decision tree can be learned by
@@ -415,7 +415,7 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
                 return true;
             }
             if (obj == null) {
-                return true;
+                return false;
             }
             if (obj instanceof TrainNode) {
                 return this.node.splitFeature == ((TrainNode)obj).node.splitScore;

--- a/core/src/main/java/smile/gap/BitString.java
+++ b/core/src/main/java/smile/gap/BitString.java
@@ -199,7 +199,7 @@ public class BitString implements Chromosome {
             return true;
         }
         if (obj == null) {
-            return true;
+            return false;
         }
         if (obj instanceof Chromosome) {
             return this.fitness == ((Chromosome)obj).fitness();

--- a/core/src/main/java/smile/gap/BitString.java
+++ b/core/src/main/java/smile/gap/BitString.java
@@ -192,7 +192,27 @@ public class BitString implements Chromosome {
     public int compareTo(Chromosome o) {
         return (int) Math.signum(fitness - o.fitness());
     }
-    
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null) {
+            return true;
+        }
+        if (obj instanceof Chromosome) {
+            return this.fitness == ((Chromosome)obj).fitness();
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        long fitnessLong = Double.doubleToLongBits(fitness);
+        return 37 + (int) (fitnessLong ^ (fitnessLong >>> 32));
+    }
+
     @Override
     public double fitness() {
         if (Double.isNaN(fitness)) {

--- a/core/src/main/java/smile/neighbor/CoverTree.java
+++ b/core/src/main/java/smile/neighbor/CoverTree.java
@@ -202,6 +202,27 @@ public class CoverTree<E> implements NearestNeighborSearch<E, E>, KNNSearch<E, E
         public int compareTo(DistanceNode o) {
             return (int) Math.signum(dist - o.dist);
         }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null) {
+                return true;
+            }
+            if (this.getClass() == obj.getClass()) {
+                return this.dist == ((DistanceNode)obj).dist;
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            long fitnessLong = Double.doubleToLongBits(dist);
+            return 31 + (int) (fitnessLong ^ (fitnessLong >>> 32));
+        }
+
     }
 
     /**

--- a/core/src/main/java/smile/neighbor/CoverTree.java
+++ b/core/src/main/java/smile/neighbor/CoverTree.java
@@ -15,12 +15,13 @@
  *******************************************************************************/
 package smile.neighbor;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import smile.math.Math;
 import smile.math.distance.Metric;
 import smile.sort.DoubleHeapSelect;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Cover tree is a data structure for generic nearest neighbor search, which
@@ -209,7 +210,7 @@ public class CoverTree<E> implements NearestNeighborSearch<E, E>, KNNSearch<E, E
                 return true;
             }
             if (obj == null) {
-                return true;
+                return false;
             }
             if (this.getClass() == obj.getClass()) {
                 return this.dist == ((DistanceNode)obj).dist;

--- a/core/src/main/java/smile/neighbor/MPLSH.java
+++ b/core/src/main/java/smile/neighbor/MPLSH.java
@@ -15,14 +15,15 @@
  *******************************************************************************/
 package smile.neighbor;
 
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.PriorityQueue;
 import smile.math.IntArrayList;
 import smile.math.Math;
 import smile.sort.HeapSelect;
 import smile.stat.distribution.GaussianDistribution;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.PriorityQueue;
 
 /**
  * Multi-Probe Locality-Sensitive Hashing. LSH is an efficient algorithm for
@@ -235,7 +236,7 @@ public class MPLSH <E> implements NearestNeighborSearch<double[], E>, KNNSearch<
                 return true;
             }
             if (obj == null) {
-                return true;
+                return false;
             }
             if (obj instanceof PrH) {
                 return this.pr == ((PrH)obj).pr;
@@ -277,7 +278,7 @@ public class MPLSH <E> implements NearestNeighborSearch<double[], E>, KNNSearch<
                 return true;
             }
             if (obj == null) {
-                return true;
+                return false;
             }
             if (obj instanceof PrZ) {
                 return this.prh[0].equals(((PrZ)obj).prh[0]);
@@ -709,7 +710,7 @@ public class MPLSH <E> implements NearestNeighborSearch<double[], E>, KNNSearch<
                 return true;
             }
             if (obj == null) {
-                return true;
+                return false;
             }
             if (this.getClass() == obj.getClass()) {
                 return this.prob == ((Probe)obj).prob;

--- a/core/src/main/java/smile/neighbor/MPLSH.java
+++ b/core/src/main/java/smile/neighbor/MPLSH.java
@@ -228,6 +228,26 @@ public class MPLSH <E> implements NearestNeighborSearch<double[], E>, KNNSearch<
             // to sort PrH in decreasing order.
             return (int) Math.signum(o.pr - pr);
         }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null) {
+                return true;
+            }
+            if (obj instanceof PrH) {
+                return this.pr == ((PrH)obj).pr;
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            long fitnessLong = Double.doubleToLongBits(pr);
+            return 37 + (int) (fitnessLong ^ (fitnessLong >>> 32));
+        }
     }
 
     /**
@@ -249,6 +269,29 @@ public class MPLSH <E> implements NearestNeighborSearch<double[], E>, KNNSearch<
         public int compareTo(PrZ o) {
             // to sort PrZ in decreasing order.
             return prh[0].compareTo(o.prh[0]);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null) {
+                return true;
+            }
+            if (obj instanceof PrZ) {
+                return this.prh[0].equals(((PrZ)obj).prh[0]);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            if (prh != null && prh.length > 0) {
+                return prh[0].hashCode();
+            } else {
+                return 0;
+            }
         }
     }
 
@@ -658,6 +701,26 @@ public class MPLSH <E> implements NearestNeighborSearch<double[], E>, KNNSearch<
         @Override
         public int compareTo(Probe o) {
             return (int) Math.signum(prob - o.prob);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null) {
+                return true;
+            }
+            if (this.getClass() == obj.getClass()) {
+                return this.prob == ((Probe)obj).prob;
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            long fitnessLong = Double.doubleToLongBits(prob);
+            return 37 + (int) (fitnessLong ^ (fitnessLong >>> 32));
         }
 
         /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1210- “""equals(Object obj)"" should be overridden along with the ""compareTo(T obj)"" method”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1210

Please let me know if you have any questions.
Ayman Elkfrawy