### PR TITLE
Fix: squid:S1948, Fields in a "Serializable" class should either be t…

### DIFF
--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -265,7 +265,7 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
     /**
      * Classification tree node.
      */
-    class Node {
+    class Node implements Serializable {
 
         /**
          * Predicted class label for this node.

--- a/plot/src/main/java/smile/plot/PlotCanvas.java
+++ b/plot/src/main/java/smile/plot/PlotCanvas.java
@@ -583,18 +583,18 @@ public class PlotCanvas extends JPanel {
     /**
      * Toolbar button actions.
      */
-    private Action saveAction = new SaveAction();
-    private Action printAction = new PrintAction();
-    private Action zoomInAction = new ZoomInAction();
-    private Action zoomOutAction = new ZoomOutAction();
-    private Action resetAction = new ResetAction();
-    private Action enlargePlotAreaAction = new EnlargePlotAreaAction();
-    private Action shrinkPlotAreaAction = new ShrinkPlotAreaAction();
-    private Action propertyAction = new PropertyAction();
-    private Action increaseHeightAction = new IncreaseHeightAction();
-    private Action increaseWidthAction = new IncreaseWidthAction();
-    private Action decreaseHeightAction = new DecreaseHeightAction();
-    private Action decreaseWidthAction = new DecreaseWidthAction();
+    private transient Action saveAction = new SaveAction();
+    private transient Action printAction = new PrintAction();
+    private transient Action zoomInAction = new ZoomInAction();
+    private transient Action zoomOutAction = new ZoomOutAction();
+    private transient Action resetAction = new ResetAction();
+    private transient Action enlargePlotAreaAction = new EnlargePlotAreaAction();
+    private transient Action shrinkPlotAreaAction = new ShrinkPlotAreaAction();
+    private transient Action propertyAction = new PropertyAction();
+    private transient Action increaseHeightAction = new IncreaseHeightAction();
+    private transient Action increaseWidthAction = new IncreaseWidthAction();
+    private transient Action decreaseHeightAction = new DecreaseHeightAction();
+    private transient Action decreaseWidthAction = new DecreaseWidthAction();
     private JScrollPane scrollPane;
 
     /**

--- a/plot/src/main/java/smile/swing/table/ButtonCellRenderer.java
+++ b/plot/src/main/java/smile/swing/table/ButtonCellRenderer.java
@@ -56,7 +56,7 @@ public class ButtonCellRenderer extends AbstractCellEditor
 	implements TableCellRenderer, TableCellEditor, ActionListener, MouseListener
 {
     private JTable table;
-    private Action action;
+    private transient Action action;
     private int mnemonic;
     private Border originalBorder;
     private Border focusBorder;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1948- “Fields in a "Serializable" class should either be transient or serializable”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1948

Please let me know if you have any questions.
Ayman Elkfrawy