### PR TITLE
Fix: squid:S1192, String literals should not be duplicated

### DIFF
--- a/core/src/main/java/smile/classification/AdaBoost.java
+++ b/core/src/main/java/smile/classification/AdaBoost.java
@@ -15,14 +15,14 @@
  *******************************************************************************/
 
 package smile.classification;
-
 import java.io.Serializable;
 import java.util.Arrays;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import smile.math.Math;
 import smile.data.Attribute;
 import smile.data.NumericAttribute;
+import smile.math.Math;
 import smile.util.SmileUtils;
 import smile.validation.Accuracy;
 import smile.validation.ClassificationMeasure;
@@ -61,6 +61,7 @@ import smile.validation.ClassificationMeasure;
 public class AdaBoost implements SoftClassifier<double[]>, Serializable {
     private static final long serialVersionUID = 1L;
     private static final Logger logger = LoggerFactory.getLogger(AdaBoost.class);
+    private static final String INVALID_NUMBER_OF_TREES = "Invalid number of trees: ";
 
     /**
      * The number of classes.
@@ -115,7 +116,7 @@ public class AdaBoost implements SoftClassifier<double[]>, Serializable {
          */
         public Trainer(int ntrees) {
             if (ntrees < 1) {
-                throw new IllegalArgumentException("Invalid number of trees: " + ntrees);
+                throw new IllegalArgumentException(INVALID_NUMBER_OF_TREES + ntrees);
             }
 
             this.ntrees = ntrees;
@@ -131,7 +132,7 @@ public class AdaBoost implements SoftClassifier<double[]>, Serializable {
             super(attributes);
 
             if (ntrees < 1) {
-                throw new IllegalArgumentException("Invalid number of trees: " + ntrees);
+                throw new IllegalArgumentException(INVALID_NUMBER_OF_TREES + ntrees);
             }
 
             this.ntrees = ntrees;
@@ -143,7 +144,7 @@ public class AdaBoost implements SoftClassifier<double[]>, Serializable {
          */
         public Trainer setNumTrees(int ntrees) {
             if (ntrees < 1) {
-                throw new IllegalArgumentException("Invalid number of trees: " + ntrees);
+                throw new IllegalArgumentException(INVALID_NUMBER_OF_TREES + ntrees);
             }
 
             this.ntrees = ntrees;
@@ -218,7 +219,7 @@ public class AdaBoost implements SoftClassifier<double[]>, Serializable {
         }
 
         if (ntrees < 1) {
-            throw new IllegalArgumentException("Invalid number of trees: " + ntrees);
+            throw new IllegalArgumentException(INVALID_NUMBER_OF_TREES + ntrees);
         }
         
         if (maxNodes < 2) {

--- a/data/src/main/java/smile/data/Dataset.java
+++ b/data/src/main/java/smile/data/Dataset.java
@@ -28,6 +28,9 @@ import java.util.List;
  * @author Haifeng Li
  */
 public class Dataset<E> implements Iterable<Datum<E>> {
+    private static final String DATASET_HAS_NO_RESPONSE = "The dataset has no response values.";
+    private static final String RESPONSE_NOT_NOMINAL = "The response variable is not nominal.";
+    private static final String RESPONSE_NOT_NUMERIC = "The response variable is not numeric.";
     /**
      * The name of dataset.
      */
@@ -146,11 +149,11 @@ public class Dataset<E> implements Iterable<Datum<E>> {
      */
     public void add(E x, int y) {
         if (response == null) {
-            throw new IllegalArgumentException("The dataset has no response values.");            
+            throw new IllegalArgumentException(DATASET_HAS_NO_RESPONSE);
         }
         
         if (response.getType() != Attribute.Type.NOMINAL) {
-            throw new IllegalArgumentException("The response variable is not nominal.");
+            throw new IllegalArgumentException(RESPONSE_NOT_NOMINAL);
         }
         
         add(new Datum<E>(x, y));
@@ -167,11 +170,11 @@ public class Dataset<E> implements Iterable<Datum<E>> {
      */
     public void add(E x, int y, double weight) {
         if (response == null) {
-            throw new IllegalArgumentException("The dataset has no response values.");            
+            throw new IllegalArgumentException(DATASET_HAS_NO_RESPONSE);
         }
         
         if (response.getType() != Attribute.Type.NOMINAL) {
-            throw new IllegalArgumentException("The response variable is not nominal.");
+            throw new IllegalArgumentException(RESPONSE_NOT_NOMINAL);
         }
         
         add(new Datum<E>(x, y, weight));
@@ -184,11 +187,11 @@ public class Dataset<E> implements Iterable<Datum<E>> {
      */
     public void add(E x, double y) {
         if (response == null) {
-            throw new IllegalArgumentException("The dataset has no response values.");            
+            throw new IllegalArgumentException(DATASET_HAS_NO_RESPONSE);
         }
         
         if (response.getType() != Attribute.Type.NUMERIC) {
-            throw new IllegalArgumentException("The response variable is not numeric.");
+            throw new IllegalArgumentException(RESPONSE_NOT_NUMERIC);
         }
         
         add(new Datum<E>(x, y));
@@ -204,11 +207,11 @@ public class Dataset<E> implements Iterable<Datum<E>> {
      */
     public void add(E x, double y, double weight) {
         if (response == null) {
-            throw new IllegalArgumentException("The dataset has no response values.");            
+            throw new IllegalArgumentException(DATASET_HAS_NO_RESPONSE);
         }
         
         if (response.getType() != Attribute.Type.NUMERIC) {
-            throw new IllegalArgumentException("The response variable is not numeric.");
+            throw new IllegalArgumentException(RESPONSE_NOT_NUMERIC);
         }
         
         add(new Datum<E>(x, y, weight));
@@ -314,11 +317,11 @@ public class Dataset<E> implements Iterable<Datum<E>> {
      */
     public int[] toArray(int[] a) {
         if (response == null) {
-            throw new IllegalArgumentException("The dataset has no response values.");            
+            throw new IllegalArgumentException(DATASET_HAS_NO_RESPONSE);
         }
         
         if (response.getType() != Attribute.Type.NOMINAL) {
-            throw new IllegalArgumentException("The response variable is not nominal.");
+            throw new IllegalArgumentException(RESPONSE_NOT_NOMINAL);
         }
         
         int n = data.size();
@@ -359,11 +362,11 @@ public class Dataset<E> implements Iterable<Datum<E>> {
      */
     public double[] toArray(double[] a) {
         if (response == null) {
-            throw new IllegalArgumentException("The dataset has no response values.");            
+            throw new IllegalArgumentException(DATASET_HAS_NO_RESPONSE);
         }
         
         if (response.getType() != Attribute.Type.NUMERIC) {
-            throw new IllegalArgumentException("The response variable is not numeric.");
+            throw new IllegalArgumentException(RESPONSE_NOT_NUMERIC);
         }
         
         int n = data.size();

--- a/data/src/main/java/smile/data/parser/ArffParser.java
+++ b/data/src/main/java/smile/data/parser/ArffParser.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-
 package smile.data.parser;
 
 import java.io.BufferedReader;
@@ -36,6 +35,7 @@ import smile.data.Datum;
 import smile.data.NominalAttribute;
 import smile.data.NumericAttribute;
 import smile.data.StringAttribute;
+
 
 /**
  * Weka ARFF (attribute relation file format) file parser. ARFF is an ASCII
@@ -86,6 +86,7 @@ public class ArffParser {
     private static final String ARFF_ATTRIBUTE_RELATIONAL = "relational";
     /** The keyword used to denote the end of the declaration of a subrelation */
     private static final String ARFF_END_SUBRELATION = "@end";
+    private static final String PREMATURE_END_OF_FILE = "premature end of file";
     /**
      * The column index of dependent/response variable.
      */
@@ -166,7 +167,7 @@ public class ArffParser {
             throw new ParseException("premature end of line", tokenizer.lineno());
         }
         if (tokenizer.ttype == StreamTokenizer.TT_EOF) {
-            throw new ParseException("premature end of file", tokenizer.lineno());
+            throw new ParseException(PREMATURE_END_OF_FILE, tokenizer.lineno());
         } else if ((tokenizer.ttype == '\'') || (tokenizer.ttype == '"')) {
             tokenizer.ttype = StreamTokenizer.TT_WORD;
         } else if ((tokenizer.ttype == StreamTokenizer.TT_WORD) && (tokenizer.sval.equals("?"))) {
@@ -190,7 +191,7 @@ public class ArffParser {
         // Get name of relation.
         getFirstToken(tokenizer);
         if (tokenizer.ttype == StreamTokenizer.TT_EOF) {
-            throw new ParseException("premature end of file", tokenizer.lineno());
+            throw new ParseException(PREMATURE_END_OF_FILE, tokenizer.lineno());
         }
         if (ARFF_RELATION.equalsIgnoreCase(tokenizer.sval)) {
             getNextToken(tokenizer);
@@ -203,7 +204,7 @@ public class ArffParser {
         // Get attribute declarations.
         getFirstToken(tokenizer);
         if (tokenizer.ttype == StreamTokenizer.TT_EOF) {
-            throw new ParseException("premature end of file", tokenizer.lineno());
+            throw new ParseException(PREMATURE_END_OF_FILE, tokenizer.lineno());
         }
 
         while (ARFF_ATTRIBUTE.equalsIgnoreCase(tokenizer.sval)) {
@@ -307,7 +308,7 @@ public class ArffParser {
         getLastToken(tokenizer, false);
         getFirstToken(tokenizer);
         if (tokenizer.ttype == StreamTokenizer.TT_EOF) {
-            throw new ParseException("premature end of file", tokenizer.lineno());
+            throw new ParseException(PREMATURE_END_OF_FILE, tokenizer.lineno());
         }
 
         return attribute;

--- a/demo/src/main/java/smile/demo/clustering/CLARANSDemo.java
+++ b/demo/src/main/java/smile/demo/clustering/CLARANSDemo.java
@@ -36,6 +36,7 @@ import smile.plot.ScatterPlot;
  */
 @SuppressWarnings("serial")
 public class CLARANSDemo extends ClusteringDemo {
+    private static final String ERROR = "Error";
     JTextField numLocalField;
     int numLocal = 10;
     JTextField maxNeighborField;
@@ -55,22 +56,22 @@ public class CLARANSDemo extends ClusteringDemo {
         try {
             numLocal = Integer.parseInt(numLocalField.getText().trim());
             if (numLocal < 5) {
-                JOptionPane.showMessageDialog(this, "Toll smal NumLocal: " + numLocal, "Error", JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(this, "Toll smal NumLocal: " + numLocal, ERROR, JOptionPane.ERROR_MESSAGE);
                 return null;
             }
         } catch (Exception e) {
-            JOptionPane.showMessageDialog(this, "Invalid NumLocal: " + numLocalField.getText(), "Error", JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(this, "Invalid NumLocal: " + numLocalField.getText(), ERROR, JOptionPane.ERROR_MESSAGE);
             return null;
         }
 
         try {
             maxNeighbor = Integer.parseInt(maxNeighborField.getText().trim());
             if (maxNeighbor < 5) {
-                JOptionPane.showMessageDialog(this, "Too small MaxNeighbor: " + maxNeighbor, "Error", JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(this, "Too small MaxNeighbor: " + maxNeighbor, ERROR, JOptionPane.ERROR_MESSAGE);
                 return null;
             }
         } catch (Exception e) {
-            JOptionPane.showMessageDialog(this, "Invalid MaxNeighbor: " + maxNeighborField.getText(), "Error", JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(this, "Invalid MaxNeighbor: " + maxNeighborField.getText(), ERROR, JOptionPane.ERROR_MESSAGE);
             return null;
         }
 

--- a/demo/src/main/java/smile/demo/clustering/ClusteringDemo.java
+++ b/demo/src/main/java/smile/demo/clustering/ClusteringDemo.java
@@ -38,6 +38,7 @@ import smile.plot.ScatterPlot;
 @SuppressWarnings("serial")
 public abstract class ClusteringDemo extends JPanel implements Runnable, ActionListener, AncestorListener {
 
+    private static final String ERROR = "Error";
     private static String[] datasetName = {
         "Gaussian/One", "Gaussian/Two", "Gaussian/Three",
         "Gaussian/Five", "Gaussian/Six", "Gaussian/Elongate",
@@ -158,16 +159,16 @@ public abstract class ClusteringDemo extends JPanel implements Runnable, ActionL
             try {
                 clusterNumber = Integer.parseInt(clusterNumberField.getText().trim());
                 if (clusterNumber < 2) {
-                    JOptionPane.showMessageDialog(this, "Invalid K: " + clusterNumber, "Error", JOptionPane.ERROR_MESSAGE);
+                    JOptionPane.showMessageDialog(this, "Invalid K: " + clusterNumber, ERROR, JOptionPane.ERROR_MESSAGE);
                     return;
                 }
 
                 if (clusterNumber > dataset[datasetIndex].length / 2) {
-                    JOptionPane.showMessageDialog(this, "Too large K: " + clusterNumber, "Error", JOptionPane.ERROR_MESSAGE);
+                    JOptionPane.showMessageDialog(this, "Too large K: " + clusterNumber, ERROR, JOptionPane.ERROR_MESSAGE);
                     return;
                 }
             } catch (Exception ex) {
-                JOptionPane.showMessageDialog(this, "Invalid K: " + clusterNumberField.getText(), "Error", JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(this, "Invalid K: " + clusterNumberField.getText(), ERROR, JOptionPane.ERROR_MESSAGE);
                 return;
             }
 

--- a/demo/src/main/java/smile/demo/plot/BarPlotDemo.java
+++ b/demo/src/main/java/smile/demo/plot/BarPlotDemo.java
@@ -30,6 +30,9 @@ import smile.plot.PlotCanvas;
  */
 @SuppressWarnings("serial")
 public class BarPlotDemo extends JPanel {
+
+    private static final String BAR_PLOT = "Bar Plot";
+
     public BarPlotDemo() {
         super(new GridLayout(1,1));
 
@@ -40,17 +43,17 @@ public class BarPlotDemo extends JPanel {
             data[j] = Math.random() - 0.5;
         }
         PlotCanvas canvas = BarPlot.plot(data, labels);
-        canvas.setTitle("Bar Plot");
+        canvas.setTitle(BAR_PLOT);
         add(canvas);
     }
 
     @Override
     public String toString() {
-        return "Bar Plot";
+        return BAR_PLOT;
     }
 
     public static void main(String[] args) {
-        JFrame frame = new JFrame("Bar Plot");
+        JFrame frame = new JFrame(BAR_PLOT);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setLocationRelativeTo(null);
         frame.getContentPane().add(new BarPlotDemo());

--- a/demo/src/main/java/smile/demo/vq/BIRCHDemo.java
+++ b/demo/src/main/java/smile/demo/vq/BIRCHDemo.java
@@ -34,6 +34,7 @@ import smile.plot.ScatterPlot;
  */
 @SuppressWarnings("serial")
 public class BIRCHDemo extends VQDemo {
+    private static final String ERROR = "Error";
     JTextField BNumberField;
     int B = 5;
 
@@ -60,33 +61,33 @@ public class BIRCHDemo extends VQDemo {
         try {
             B = Integer.parseInt(BNumberField.getText().trim());
             if (B < 2) {
-                JOptionPane.showMessageDialog(this, "Invalid B: " + B, "Error", JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(this, "Invalid B: " + B, ERROR, JOptionPane.ERROR_MESSAGE);
                 return null;
             }
         } catch (Exception e) {
-            JOptionPane.showMessageDialog(null, "Invalid B: " + BNumberField.getText(), "Error", JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(null, "Invalid B: " + BNumberField.getText(), ERROR, JOptionPane.ERROR_MESSAGE);
             return null;
         }
 
         try {
             T = Double.parseDouble(TNumberField.getText().trim());
             if (T <= 0) {
-                JOptionPane.showMessageDialog(this, "Invalid T: " + T, "Error", JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(this, "Invalid T: " + T, ERROR, JOptionPane.ERROR_MESSAGE);
                 return null;
             }
         } catch (Exception e) {
-            JOptionPane.showMessageDialog(this, "Invalid T: " + TNumberField.getText(), "Error", JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(this, "Invalid T: " + TNumberField.getText(), ERROR, JOptionPane.ERROR_MESSAGE);
             return null;
         }
 
         try {
             minPts = Integer.parseInt(minPtsNumberField.getText().trim());
             if (minPts < 0) {
-                JOptionPane.showMessageDialog(this, "Invalid minPts: " + minPts, "Error", JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(this, "Invalid minPts: " + minPts, ERROR, JOptionPane.ERROR_MESSAGE);
                 return null;
             }
         } catch (Exception e) {
-            JOptionPane.showMessageDialog(this, "Invalid minPts: " + minPtsNumberField.getText(), "Error", JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(this, "Invalid minPts: " + minPtsNumberField.getText(), ERROR, JOptionPane.ERROR_MESSAGE);
             return null;
         }
 

--- a/plot/src/main/java/smile/plot/Base.java
+++ b/plot/src/main/java/smile/plot/Base.java
@@ -16,6 +16,7 @@
 package smile.plot;
 
 import java.util.Arrays;
+
 import smile.math.Math;
 
 /**
@@ -29,6 +30,7 @@ import smile.math.Math;
  */
 public class Base {
 
+    private static final String BOUND_SIZE_DON_T_MATCH_THE_DIMENSION = "Bound size don't match the dimension.";
     /**
      * The dimensionality of base. Should be 2 or 3.
      */
@@ -229,7 +231,7 @@ public class Base {
      */
     public void extendLowerBound(double[] bound) {
         if (bound.length != dimension) {
-            throw new IllegalArgumentException("Bound size don't match the dimension.");
+            throw new IllegalArgumentException(BOUND_SIZE_DON_T_MATCH_THE_DIMENSION);
         }
 
         boolean extend = false;
@@ -250,7 +252,7 @@ public class Base {
      */
     public void extendUpperBound(double[] bound) {
         if (bound.length != dimension) {
-            throw new IllegalArgumentException("Bound size don't match the dimension.");
+            throw new IllegalArgumentException(BOUND_SIZE_DON_T_MATCH_THE_DIMENSION);
         }
 
         boolean extend = false;
@@ -271,7 +273,7 @@ public class Base {
      */
     public void extendBound(double[] lowerBound, double[] upperBound) {
         if (lowerBound.length != dimension || upperBound.length != dimension) {
-            throw new IllegalArgumentException("Bound size don't match the dimension.");
+            throw new IllegalArgumentException(BOUND_SIZE_DON_T_MATCH_THE_DIMENSION);
         }
 
         boolean extend = false;

--- a/plot/src/main/java/smile/plot/Contour.java
+++ b/plot/src/main/java/smile/plot/Contour.java
@@ -18,6 +18,7 @@ package smile.plot;
 import java.awt.Color;
 import java.util.ArrayList;
 import java.util.List;
+
 import smile.math.Math;
 
 /**
@@ -31,6 +32,8 @@ import smile.math.Math;
  */
 public class Contour extends Plot {
 
+    private static final String DIMENSIONS_XZ_DONT_MATCH = "The dimensions of x and z don't match.";
+    private static final String DIMENSIONS_YZ_DONT_MATCH = "The dimensions of y and z don't match.";
     /**
      * The x coordinate of surface.
      */
@@ -278,11 +281,11 @@ public class Contour extends Plot {
      */
     public Contour(double[] x, double[] y, double[][] z) {
         if (x.length != z[0].length) {
-            throw new IllegalArgumentException("The dimensions of x and z don't match.");
+            throw new IllegalArgumentException(DIMENSIONS_XZ_DONT_MATCH);
         }
 
         if (y.length != z.length) {
-            throw new IllegalArgumentException("The dimensions of y and z don't match.");
+            throw new IllegalArgumentException(DIMENSIONS_YZ_DONT_MATCH);
         }
 
         this.x = x;
@@ -300,11 +303,11 @@ public class Contour extends Plot {
      */
     public Contour(double[] x, double[] y, double[][] z, int numLevels) {
         if (x.length != z[0].length) {
-            throw new IllegalArgumentException("The dimensions of x and z don't match.");
+            throw new IllegalArgumentException(DIMENSIONS_XZ_DONT_MATCH);
         }
 
         if (y.length != z.length) {
-            throw new IllegalArgumentException("The dimensions of y and z don't match.");
+            throw new IllegalArgumentException(DIMENSIONS_YZ_DONT_MATCH);
         }
 
         this.x = x;
@@ -324,11 +327,11 @@ public class Contour extends Plot {
      */
     public Contour(double[] x, double[] y, double[][] z, int numLevels, boolean logScale) {
         if (x.length != z[0].length) {
-            throw new IllegalArgumentException("The dimensions of x and z don't match.");
+            throw new IllegalArgumentException(DIMENSIONS_XZ_DONT_MATCH);
         }
 
         if (y.length != z.length) {
-            throw new IllegalArgumentException("The dimensions of y and z don't match.");
+            throw new IllegalArgumentException(DIMENSIONS_YZ_DONT_MATCH);
         }
 
         this.x = x;
@@ -348,11 +351,11 @@ public class Contour extends Plot {
      */
     public Contour(double[] x, double[] y, double[][] z, double[] levels) {
         if (x.length != z[0].length) {
-            throw new IllegalArgumentException("The dimensions of x and z don't match.");
+            throw new IllegalArgumentException(DIMENSIONS_XZ_DONT_MATCH);
         }
 
         if (y.length != z.length) {
-            throw new IllegalArgumentException("The dimensions of y and z don't match.");
+            throw new IllegalArgumentException(DIMENSIONS_YZ_DONT_MATCH);
         }
 
         this.x = x;
@@ -372,11 +375,11 @@ public class Contour extends Plot {
      */
     public Contour(double[] x, double[] y, double[][] z, double[] levels, Color[] colors) {
         if (x.length != z[0].length) {
-            throw new IllegalArgumentException("The dimensions of x and z don't match.");
+            throw new IllegalArgumentException(DIMENSIONS_XZ_DONT_MATCH);
         }
 
         if (y.length != z.length) {
-            throw new IllegalArgumentException("The dimensions of y and z don't match.");
+            throw new IllegalArgumentException(DIMENSIONS_YZ_DONT_MATCH);
         }
 
         if (levels.length != colors.length) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1192 - “String literals should not be duplicated”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1192

 Please let me know if you have any questions.
Ayman Elkfrawy.