### PR TITLE
Fix: squid:S1118, Utility classes should not have public constructors

### DIFF
--- a/core/src/main/java/smile/neighbor/SNLSH.java
+++ b/core/src/main/java/smile/neighbor/SNLSH.java
@@ -214,6 +214,9 @@ public class SNLSH<E> implements NearestNeighborSearch<SNLSH.AbstractSentence, E
     public static class SimHash {
         private static final long seed = 0; //do not change seed
 
+        private SimHash() {
+        }
+
         public static long simhash64(List<String> tokens) {
             final int BITS = 64;
             if (tokens == null || tokens.isEmpty()) {

--- a/core/src/main/java/smile/util/MulticoreExecutor.java
+++ b/core/src/main/java/smile/util/MulticoreExecutor.java
@@ -43,6 +43,9 @@ public class MulticoreExecutor {
      */
     private static ThreadPoolExecutor threads = null;
 
+    private MulticoreExecutor() {
+    }
+
     /** Creates the worker thread pool. */
     private static void createThreadPool() {
         if (nprocs == -1) {

--- a/core/src/main/java/smile/util/SmileUtils.java
+++ b/core/src/main/java/smile/util/SmileUtils.java
@@ -32,6 +32,9 @@ import smile.sort.QuickSort;
  * @author Haifeng Li
  */
 public class SmileUtils {
+    private SmileUtils() {
+    }
+
     /**
      * Sorts each variable and returns the index of values in ascending order.
      * Only numeric attributes will be sorted. Note that the order of original

--- a/core/src/main/java/smile/validation/AUC.java
+++ b/core/src/main/java/smile/validation/AUC.java
@@ -40,7 +40,7 @@ import smile.sort.QuickSort;
  */
 public class AUC {
 
-    public AUC() {
+    private AUC() {
     }
 
     /**

--- a/core/src/main/java/smile/validation/Validation.java
+++ b/core/src/main/java/smile/validation/Validation.java
@@ -27,6 +27,9 @@ import smile.regression.RegressionTrainer;
  * @author Haifeng
  */
 public class Validation {
+    private Validation() {
+    }
+
     /**
      * Tests a classifier on a validation set.
      * 

--- a/core/src/main/java/smile/wavelet/WaveletShrinkage.java
+++ b/core/src/main/java/smile/wavelet/WaveletShrinkage.java
@@ -46,6 +46,9 @@ import smile.math.Math;
  * @author Haifeng Li
  */
 public class WaveletShrinkage {
+    private WaveletShrinkage() {
+    }
+
     /**
      * Adaptive hard-thresholding denoising a time series with given wavelet.
      *

--- a/data/src/main/java/smile/data/parser/IOUtils.java
+++ b/data/src/main/java/smile/data/parser/IOUtils.java
@@ -28,6 +28,9 @@ import java.util.List;
 public class IOUtils {
     private static String home = System.getProperty("smile.home", "shell/src/universal/bin");
 
+    private IOUtils() {
+    }
+
     /** Get the file path of sample dataset. */
     public static String getTestDataPath(String path) {
         return home + "/../data/" + path;

--- a/demo/src/main/java/smile/demo/math/MathDemo.java
+++ b/demo/src/main/java/smile/demo/math/MathDemo.java
@@ -23,6 +23,9 @@ import smile.math.Math;
  * @author Haifeng Li
  */
 public class MathDemo {
+    private MathDemo() {
+    }
+
     public static void main(String[] args) {
         int[] x = Math.permutate(10);
         for (int i = 0; i < x.length; i++) {

--- a/interpolation/src/main/java/smile/interpolation/LaplaceInterpolation.java
+++ b/interpolation/src/main/java/smile/interpolation/LaplaceInterpolation.java
@@ -27,6 +27,9 @@ import java.util.Arrays;
  */
 public class LaplaceInterpolation {
 
+    private LaplaceInterpolation() {
+    }
+
     /**
      * Laplace interpolation.
      * @param matrix on input, values of NaN are deemed to be missing data.

--- a/math/src/main/java/smile/hash/MurmurHash.java
+++ b/math/src/main/java/smile/hash/MurmurHash.java
@@ -32,6 +32,9 @@ import java.nio.ByteBuffer;
  * This class is copied from Apache Cassandra.
  */
 public class MurmurHash {
+    private MurmurHash() {
+    }
+
     public static int hash32(ByteBuffer data, int offset, int length, int seed) {
         int m = 0x5bd1e995;
         int r = 24;

--- a/math/src/main/java/smile/math/Histogram.java
+++ b/math/src/main/java/smile/math/Histogram.java
@@ -36,6 +36,9 @@ import java.util.Arrays;
  * @author Haifeng Li
  */
 public class Histogram {
+    private Histogram() {
+    }
+
     /**
      * Generate the histogram of given data. The number of bins k is decided by
      * square-root choice.

--- a/math/src/main/java/smile/math/special/Beta.java
+++ b/math/src/main/java/smile/math/special/Beta.java
@@ -36,6 +36,9 @@ public class Beta {
      */
     private static final double FPMIN = 1e-300;
 
+    private Beta() {
+    }
+
     /**
      * Beta function, also called the Euler integral of the first kind.
      * The beta function is symmetric, i.e. B(x,y)==B(y,x).

--- a/math/src/main/java/smile/math/special/Erf.java
+++ b/math/src/main/java/smile/math/special/Erf.java
@@ -42,6 +42,9 @@ public class Erf {
         -1.12708e-13, 3.81e-16, 7.106e-15, -1.523e-15, -9.4e-17, 1.21e-16, -2.8e-17
     };
 
+    private Erf() {
+    }
+
     /**
      * The Gauss error function.
      */

--- a/math/src/main/java/smile/math/special/Gamma.java
+++ b/math/src/main/java/smile/math/special/Gamma.java
@@ -52,6 +52,9 @@ public class Gamma {
      */
     private static final double INCOMPLETE_GAMMA_EPSILON = 1.0E-8;
 
+    private Gamma() {
+    }
+
     /**
      * Gamma function. Lanczos approximation (6 terms).
      */

--- a/math/src/main/java/smile/sort/HeapSort.java
+++ b/math/src/main/java/smile/sort/HeapSort.java
@@ -27,6 +27,9 @@ package smile.sort;
  * @author Haifeng Li
  */
 public class HeapSort {
+    private HeapSort() {
+    }
+
     /**
      * Sorts the specified array into ascending numerical order.
      */

--- a/math/src/main/java/smile/sort/QuickSelect.java
+++ b/math/src/main/java/smile/sort/QuickSelect.java
@@ -28,6 +28,9 @@ package smile.sort;
  * @author Haifeng Li
  */
 public class QuickSelect {
+    private QuickSelect() {
+    }
+
     /**
      * Given k in [0, n-1], returns an array value from arr such that k array
      * values are less than or equal to the one returned. The input array will

--- a/math/src/main/java/smile/sort/QuickSort.java
+++ b/math/src/main/java/smile/sort/QuickSort.java
@@ -56,6 +56,9 @@ public class QuickSort {
     private static final int M = 7;
     private static final int NSTACK = 64;
 
+    private QuickSort() {
+    }
+
     /**
      * Sorts the specified array into ascending numerical order.
      * @return the original index of elements after sorting in range [0, n).

--- a/math/src/main/java/smile/sort/ShellSort.java
+++ b/math/src/main/java/smile/sort/ShellSort.java
@@ -43,6 +43,9 @@ package smile.sort;
  */
 public class ShellSort {
 
+    private ShellSort() {
+    }
+
     /**
      * Sorts the specified array into ascending numerical order.
      */

--- a/math/src/main/java/smile/sort/SortUtils.java
+++ b/math/src/main/java/smile/sort/SortUtils.java
@@ -23,6 +23,9 @@ package smile.sort;
  * @author Haifeng Li
  */
 public class SortUtils {
+    private SortUtils() {
+    }
+
     /**
      * Swap two positions.
      */

--- a/math/src/main/java/smile/stat/distribution/BIC.java
+++ b/math/src/main/java/smile/stat/distribution/BIC.java
@@ -38,6 +38,9 @@ package smile.stat.distribution;
  */
 public class BIC {
 
+    private BIC() {
+    }
+
     /**
      * Returns the BIC score of an estimated model.
      * @param L the log-likelihood of estimated model.

--- a/nlp/src/main/java/smile/nlp/pos/EnglishPOSLexicon.java
+++ b/nlp/src/main/java/smile/nlp/pos/EnglishPOSLexicon.java
@@ -139,6 +139,9 @@ public class EnglishPOSLexicon {
         }
     }
 
+    private EnglishPOSLexicon() {
+    }
+
     /**
      * Returns part-of-speech tags for given word, or null if the word does
      * not exist in the dictionary.

--- a/nlp/src/main/java/smile/nlp/pos/RegexPOSTagger.java
+++ b/nlp/src/main/java/smile/nlp/pos/RegexPOSTagger.java
@@ -55,6 +55,9 @@ class RegexPOSTagger {
         PennTreebankPOS.NN
     };
 
+    private RegexPOSTagger() {
+    }
+
     /**
      * Returns the POS tag of a given word based on the regular expression over
      * word string. Returns null if no match.

--- a/nlp/src/main/java/smile/nlp/tokenizer/EnglishAbbreviations.java
+++ b/nlp/src/main/java/smile/nlp/tokenizer/EnglishAbbreviations.java
@@ -51,6 +51,9 @@ class EnglishAbbreviations {
         }
     }
 
+    private EnglishAbbreviations() {
+    }
+
     /**
      * Returns true if this abbreviation dictionary contains the specified element.
      */

--- a/plot/src/main/java/smile/plot/Palette.java
+++ b/plot/src/main/java/smile/plot/Palette.java
@@ -109,6 +109,9 @@ public class Palette {
         BLACK,
     };
 
+    private Palette() {
+    }
+
     /**
      * Generate terrain color palette.
      * @param n the number of colors in the palette.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Elkfrawy.
