### PR TITLE
Fix: squid:S1155, Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/core/src/main/java/smile/classification/SVM.java
+++ b/core/src/main/java/smile/classification/SVM.java
@@ -750,7 +750,7 @@ public class SVM <T> implements OnlineClassifier<T>, Serializable {
             // Compute gradient
             double g = y;
             DoubleArrayList kcache = new DoubleArrayList(sv.size() + 1);
-            if (sv.size() > 0) {
+            if (!sv.isEmpty()) {
                 for (SupportVector v : sv) {
                     if (v != null) {
                         // Bail out if already in expansion?

--- a/core/src/main/java/smile/clustering/MEC.java
+++ b/core/src/main/java/smile/clustering/MEC.java
@@ -230,7 +230,7 @@ public class MEC <T> extends PartitionClustering<T> {
         // The number of samples with nonzero conditional entropy.
         entropy = 0.0;
         for (int i = 0; i < n; i++) {
-            if (neighbors.get(i).size() > 0) {
+            if (!neighbors.get(i).isEmpty()) {
                 int ni = neighbors.get(i).size();
                 double m = 0.0;
                 for (int j = 0; j < k; j++) {
@@ -295,7 +295,7 @@ public class MEC <T> extends PartitionClustering<T> {
             double prevObj = entropy;
             entropy = 0.0;
             for (int i = 0; i < n; i++) {
-                if (neighbors.get(i).size() > 0) {
+                if (!neighbors.get(i).isEmpty()) {
                     int ni = neighbors.get(i).size();
                     double m = 0.0;
                     for (int j = 0; j < k; j++) {

--- a/core/src/main/java/smile/neighbor/CoverTree.java
+++ b/core/src/main/java/smile/neighbor/CoverTree.java
@@ -304,7 +304,7 @@ public class CoverTree<E> implements NearestNeighborSearch<E, E>, KNNSearch<E, E
                 ArrayList<Node> children = new ArrayList<Node>();
                 Node leaf = newLeaf(p);
                 children.add(leaf);
-                while (pointSet.size() > 0) {
+                while (!pointSet.isEmpty()) {
                     DistanceSet set = pointSet.get(pointSet.size() - 1);
                     pointSet.remove(pointSet.size() - 1);
                     leaf = newLeaf(set.idx);
@@ -533,7 +533,7 @@ public class CoverTree<E> implements NearestNeighborSearch<E, E>, KNNSearch<E, E
             emptyHeap = false;
         }
 
-        while (currentCoverSet.size() > 0) {
+        while (!currentCoverSet.isEmpty()) {
             ArrayList<DistanceNode> nextCoverSet = new ArrayList<DistanceNode>();
             for (int i = 0; i < currentCoverSet.size(); i++) {
                 DistanceNode par = currentCoverSet.get(i);
@@ -597,7 +597,7 @@ public class CoverTree<E> implements NearestNeighborSearch<E, E>, KNNSearch<E, E
         double d = distance.d(root.getObject(), q);
         currentCoverSet.add(new DistanceNode(d, root));
 
-        while (currentCoverSet.size() > 0) {
+        while (!currentCoverSet.isEmpty()) {
             ArrayList<DistanceNode> nextCoverSet = new ArrayList<DistanceNode>();
             for (int i = 0; i < currentCoverSet.size(); i++) {
                 DistanceNode par = currentCoverSet.get(i);

--- a/core/src/main/java/smile/taxonomy/Concept.java
+++ b/core/src/main/java/smile/taxonomy/Concept.java
@@ -366,7 +366,7 @@ public class Concept {
     @Override
     public String toString() {
         String displayName = "anonymous";
-        if (synset != null && synset.size() > 0) {
+        if (synset != null && !synset.isEmpty()) {
             StringBuilder builder = new StringBuilder();
             builder.append('(');
             Iterator<String> iter = synset.iterator();

--- a/core/src/main/java/smile/vq/GrowingNeuralGas.java
+++ b/core/src/main/java/smile/vq/GrowingNeuralGas.java
@@ -316,11 +316,11 @@ public class GrowingNeuralGas implements Clustering<double[]> {
                     edge.a.edges.remove(edge);
                     // If it results in neuron having no emanating edges,
                     // remove the neuron as well.
-                    if (edge.a.edges.size() == 0)
+                    if (edge.a.edges.isEmpty())
                         nodes.remove(edge.a);
                 } else {
                     edge.b.edges.remove(edge);
-                    if (edge.b.edges.size() == 0)
+                    if (edge.b.edges.isEmpty())
                         nodes.remove(edge.b);
                 }
             }

--- a/core/src/main/java/smile/vq/NeuralMap.java
+++ b/core/src/main/java/smile/vq/NeuralMap.java
@@ -502,14 +502,14 @@ public class NeuralMap implements Clustering<double[]> {
                 iter.remove();
             }
 
-            if (neighbor.neighbors.size() > 0) {
+            if (!neighbor.neighbors.isEmpty()) {
                 lsh.add(neighbor);
             } else {
                 neurons.remove(neighbor);
             }
         }
 
-        if (neuron.neighbors.size() == 0) {
+        if (neuron.neighbors.isEmpty()) {
             lsh.remove(neuron);
             neurons.remove(neuron);
         }

--- a/core/src/test/java/smile/neighbor/LSHTest.java
+++ b/core/src/test/java/smile/neighbor/LSHTest.java
@@ -161,7 +161,7 @@ public class LSHTest {
                     }
                 }
             }
-            if (n2.size() > 0) {
+            if (!n2.isEmpty()) {
                 recall += 1.0 * hit / n2.size();
             }
         }

--- a/core/src/test/java/smile/neighbor/MPLSHTest.java
+++ b/core/src/test/java/smile/neighbor/MPLSHTest.java
@@ -161,7 +161,7 @@ public class MPLSHTest {
                     }
                 }
             }
-            if (n2.size() > 0) {
+            if (!n2.isEmpty()) {
                 recall += 1.0 * hit / n2.size();
             }
         }

--- a/core/src/test/java/smile/neighbor/SNLSHTest.java
+++ b/core/src/test/java/smile/neighbor/SNLSHTest.java
@@ -52,12 +52,12 @@ public class SNLSHTest {
 
         private List<String> tokenize(String line, String regex) {
             List<String> tokens = new LinkedList<String>();
-            if (line == null || line.length() == 0) {
+            if (line == null || line.isEmpty()) {
                 throw new IllegalArgumentException("Line should not be blank!");
             }
             String[] ss = line.split(regex);
             for (String s : ss) {
-                if (s == null || s.length() == 0) {
+                if (s == null || s.isEmpty()) {
                     continue;
                 }
                 tokens.add(s);
@@ -263,7 +263,7 @@ public class SNLSHTest {
                     }
                 }
             }
-            if (n2.size() > 0) {
+            if (!n2.isEmpty()) {
                 recall += 1.0 * hit / n2.size();
             }
         }
@@ -281,12 +281,12 @@ public class SNLSHTest {
 
     private List<String> tokenize(String line, String regex) {
         List<String> tokens = new LinkedList<String>();
-        if (line == null || line.length() == 0) {
+        if (line == null || line.isEmpty()) {
             throw new IllegalArgumentException("Line should not be blank!");
         }
         String[] ss = line.split(regex);
         for (String s : ss) {
-            if (s == null || s.length() == 0) {
+            if (s == null || s.isEmpty()) {
                 continue;
             }
             tokens.add(s);

--- a/graph/src/main/java/smile/graph/AdjacencyList.java
+++ b/graph/src/main/java/smile/graph/AdjacencyList.java
@@ -451,7 +451,7 @@ public class AdjacencyList implements Graph {
             }
         }
 
-        for (int i = 0; queue.size() > 0; i++) {
+        for (int i = 0; !queue.isEmpty(); i++) {
             int t = queue.poll();
             ts[i] = t;
             for (Edge edge : graph[t]) {
@@ -475,7 +475,7 @@ public class AdjacencyList implements Graph {
         cc[v] = id;
         Queue<Integer> queue = new LinkedList<Integer>();
         queue.offer(v);
-        while (queue.size() > 0) {
+        while (!queue.isEmpty()) {
             int t = queue.poll();
             for (Edge edge : graph[t]) {
                 int i = edge.v2;
@@ -533,7 +533,7 @@ public class AdjacencyList implements Graph {
         cc[v] = id;
         Queue<Integer> queue = new LinkedList<Integer>();
         queue.offer(v);
-        while (queue.size() > 0) {
+        while (!queue.isEmpty()) {
             int t = queue.poll();
             for (Edge edge : graph[t]) {
                 int i = edge.v2;

--- a/graph/src/main/java/smile/graph/AdjacencyMatrix.java
+++ b/graph/src/main/java/smile/graph/AdjacencyMatrix.java
@@ -390,7 +390,7 @@ public class AdjacencyMatrix implements Graph {
             }
         }
 
-        for (int i = 0; queue.size() > 0; i++) {
+        for (int i = 0; !queue.isEmpty(); i++) {
             int t = queue.poll();
             ts[i] = t;
             for (int v = 0; v < n; v++) {
@@ -415,7 +415,7 @@ public class AdjacencyMatrix implements Graph {
         cc[v] = id;
         Queue<Integer> queue = new LinkedList<Integer>();
         queue.offer(v);
-        while (queue.size() > 0) {
+        while (!queue.isEmpty()) {
             int t = queue.poll();
             for (int i = 0; i < n; i++) {
                 if (graph[t][i] != 0.0 && cc[i] == -1) {
@@ -469,7 +469,7 @@ public class AdjacencyMatrix implements Graph {
         cc[v] = id;
         Queue<Integer> queue = new LinkedList<Integer>();
         queue.offer(v);
-        while (queue.size() > 0) {
+        while (!queue.isEmpty()) {
             int t = queue.poll();
             for (int i = 0; i < n; i++) {
                 if (graph[t][i] != 0.0 && cc[i] == -1) {

--- a/math/src/main/java/smile/stat/distribution/DiscreteMixture.java
+++ b/math/src/main/java/smile/stat/distribution/DiscreteMixture.java
@@ -73,7 +73,7 @@ public class DiscreteMixture extends DiscreteDistribution {
 
     @Override
     public double mean() {
-        if (components.size() == 0) {
+        if (components.isEmpty()) {
             throw new IllegalStateException("Mixture is empty!");
         }
 
@@ -88,7 +88,7 @@ public class DiscreteMixture extends DiscreteDistribution {
 
     @Override
     public double var() {
-        if (components.size() == 0) {
+        if (components.isEmpty()) {
             throw new IllegalStateException("Mixture is empty!");
         }
 
@@ -131,7 +131,7 @@ public class DiscreteMixture extends DiscreteDistribution {
 
     @Override
     public double logp(int x) {
-        if (components.size() == 0) {
+        if (components.isEmpty()) {
             throw new IllegalStateException("Mixture is empty!");
         }
 
@@ -140,7 +140,7 @@ public class DiscreteMixture extends DiscreteDistribution {
 
     @Override
     public double cdf(double x) {
-        if (components.size() == 0) {
+        if (components.isEmpty()) {
             throw new IllegalStateException("Mixture is empty!");
         }
 
@@ -155,7 +155,7 @@ public class DiscreteMixture extends DiscreteDistribution {
 
     @Override
     public double rand() {
-        if (components.size() == 0) {
+        if (components.isEmpty()) {
             throw new IllegalStateException("Mixture is empty!");
         }
 
@@ -175,7 +175,7 @@ public class DiscreteMixture extends DiscreteDistribution {
 
     @Override
     public double quantile(double p) {
-        if (components.size() == 0) {
+        if (components.isEmpty()) {
             throw new IllegalStateException("Mixture is empty!");
         }
 
@@ -208,7 +208,7 @@ public class DiscreteMixture extends DiscreteDistribution {
 
     @Override
     public int npara() {
-        if (components.size() == 0) {
+        if (components.isEmpty()) {
             throw new IllegalStateException("Mixture is empty!");
         }
 
@@ -231,7 +231,7 @@ public class DiscreteMixture extends DiscreteDistribution {
      * BIC score of the mixture for given data.
      */
     public double bic(double[] data) {
-        if (components.size() == 0) {
+        if (components.isEmpty()) {
             throw new IllegalStateException("Mixture is empty!");
         }
 

--- a/nlp/src/main/java/smile/nlp/pos/HMMPOSTagger.java
+++ b/nlp/src/main/java/smile/nlp/pos/HMMPOSTagger.java
@@ -355,7 +355,7 @@ public class HMMPOSTagger implements POSTagger, Serializable {
                 while ((line = reader.readLine()) != null) {
                     line = line.trim();
                     if (line.isEmpty()) {
-                        if (sent.size() > 0) {
+                        if (!sent.isEmpty()) {
                             sentences.add(sent.toArray(new String[sent.size()]));
                             labels.add(label.toArray(new PennTreebankPOS[label.size()]));
                             sent.clear();
@@ -378,7 +378,7 @@ public class HMMPOSTagger implements POSTagger, Serializable {
                     }
                 }
                 
-                if (sent.size() > 0) {
+                if (!sent.isEmpty()) {
                     sentences.add(sent.toArray(new String[sent.size()]));
                     labels.add(label.toArray(new PennTreebankPOS[label.size()]));
                     sent.clear();

--- a/nlp/src/main/java/smile/nlp/tokenizer/BreakIteratorTokenizer.java
+++ b/nlp/src/main/java/smile/nlp/tokenizer/BreakIteratorTokenizer.java
@@ -55,7 +55,7 @@ public class BreakIteratorTokenizer implements Tokenizer {
 
         while (end != BreakIterator.DONE) {
             String word = text.substring(start, end).trim();
-            if (word.length() > 0) {
+            if (!word.isEmpty()) {
                 words.add(word);
             }
             start = end;

--- a/nlp/src/test/java/smile/nlp/pos/HMMPOSTaggerTest.java
+++ b/nlp/src/test/java/smile/nlp/pos/HMMPOSTaggerTest.java
@@ -59,7 +59,7 @@ public class HMMPOSTaggerTest {
                 while ((line = reader.readLine()) != null) {
                     line = line.trim();
                     if (line.isEmpty()) {
-                        if (sent.size() > 0) {
+                        if (!sent.isEmpty()) {
                             sentences.add(sent.toArray(new String[sent.size()]));
                             labels.add(label.toArray(new PennTreebankPOS[label.size()]));
                             sent.clear();
@@ -82,7 +82,7 @@ public class HMMPOSTaggerTest {
                     }
                 }
                 
-                if (sent.size() > 0) {
+                if (!sent.isEmpty()) {
                     sentences.add(sent.toArray(new String[sent.size()]));
                     labels.add(label.toArray(new PennTreebankPOS[label.size()]));
                     sent.clear();

--- a/plot/src/main/java/smile/plot/Axis.java
+++ b/plot/src/main/java/smile/plot/Axis.java
@@ -504,7 +504,7 @@ public class Axis {
                 int prevx = xy[0];
                 int prevy = xy[1];
                 for (int i = 0; i < gridLabels.length; i++) {
-                    if (gridLabels[i].text.length() > 0) {
+                    if (!gridLabels[i].text.isEmpty()) {
                         double[] coord = gridLabels[i].getCoordinate();
                         xy = g.projection.screenProjection(coord);
                         int x = xy[0];

--- a/plot/src/main/java/smile/plot/Contour.java
+++ b/plot/src/main/java/smile/plot/Contour.java
@@ -789,7 +789,7 @@ public class Contour extends Plot {
                         }
                         contour.add(s.x1, s.y1);
                         
-                        if (contour.points.size() > 0) {
+                        if (!contour.points.isEmpty()) {
                             contours.add(contour);
                         }
                     }

--- a/plot/src/main/java/smile/swing/FontChooser.java
+++ b/plot/src/main/java/smile/swing/FontChooser.java
@@ -539,7 +539,7 @@ public class FontChooser extends JComponent {
                 logger.error("update(DocumentEvent) exception", ex);
             }
 
-            if (newValue.length() > 0) {
+            if (!newValue.isEmpty()) {
                 int index = targetList.getNextMatch(newValue, 0, Position.Bias.Forward);
                 if (index < 0) {
                     index = 0;

--- a/plot/src/main/java/smile/swing/table/DefaultTableHeaderCellRenderer.java
+++ b/plot/src/main/java/smile/swing/table/DefaultTableHeaderCellRenderer.java
@@ -127,7 +127,7 @@ public class DefaultTableHeaderCellRenderer extends DefaultTableCellRenderer {
         }
 
         List sortedColumns = rowSorter.getSortKeys();
-        if (sortedColumns.size() > 0) {
+        if (!sortedColumns.isEmpty()) {
             return (SortKey) sortedColumns.get(0);
         }
         return null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1155

 Please let me know if you have any questions.
Ayman Elkfrawy.