### PR TITLE
Fix: squid:S2130, Parsing should be used to convert "Strings" to prim…

### DIFF
--- a/core/src/test/java/smile/classification/MaxentTest.java
+++ b/core/src/test/java/smile/classification/MaxentTest.java
@@ -49,20 +49,20 @@ public class MaxentTest {
 
         try (BufferedReader input = new BufferedReader(new InputStreamReader(this.getClass().getResourceAsStream(resource)))) {
             String[] words = input.readLine().split(" ");
-            int nseq = Integer.valueOf(words[0]);
-            int k = Integer.valueOf(words[1]);
-            p = Integer.valueOf(words[2]);
+            int nseq = Integer.parseInt(words[0]);
+            int k = Integer.parseInt(words[1]);
+            p = Integer.parseInt(words[2]);
 
             String line = null;
             while ((line = input.readLine()) != null) {
                 words = line.split(" ");
-                int seqid = Integer.valueOf(words[0]);
-                int pos = Integer.valueOf(words[1]);
-                int len = Integer.valueOf(words[2]);
+                int seqid = Integer.parseInt(words[0]);
+                int pos = Integer.parseInt(words[1]);
+                int len = Integer.parseInt(words[2]);
 
                 int[] feature = new int[len];
                 for (int i = 0; i < len; i++) {
-                    feature[i] = Integer.valueOf(words[i+3]);
+                    feature[i] = Integer.parseInt(words[i+3]);
                 }
 
                 x.add(feature);

--- a/core/src/test/java/smile/sequence/CRFTest.java
+++ b/core/src/test/java/smile/sequence/CRFTest.java
@@ -67,21 +67,21 @@ public class CRFTest {
         int id = 1;
         try(BufferedReader input = new BufferedReader(new InputStreamReader(this.getClass().getResourceAsStream(resource)))) {
             String[] words = input.readLine().split(" ");
-            int nseq = Integer.valueOf(words[0]);
-            k = Integer.valueOf(words[1]);
-            p = Integer.valueOf(words[2]);
+            int nseq = Integer.parseInt(words[0]);
+            k = Integer.parseInt(words[1]);
+            p = Integer.parseInt(words[2]);
 
             String line = null;
             while ((line = input.readLine()) != null) {
                 words = line.split(" ");
-                int seqid = Integer.valueOf(words[0]);
-                int pos = Integer.valueOf(words[1]);
-                int len = Integer.valueOf(words[2]);
+                int seqid = Integer.parseInt(words[0]);
+                int pos = Integer.parseInt(words[1]);
+                int len = Integer.parseInt(words[2]);
                 
                 int[] feature = new int[len];
                 for (int i = 0; i < len; i++) {
                     try {
-                        feature[i] = Integer.valueOf(words[i+3]);
+                        feature[i] = Integer.parseInt(words[i+3]);
                     } catch (Exception ex) {
                         System.err.println(ex);
                     }
@@ -147,16 +147,16 @@ public class CRFTest {
         int id = 1;
         try(BufferedReader input = new BufferedReader(new InputStreamReader(this.getClass().getResourceAsStream(resource)))) {
             String[] words = input.readLine().split(" ");
-            int nseq = Integer.valueOf(words[0]);
-            k = Integer.valueOf(words[1]);
-            p = Integer.valueOf(words[2]);
+            int nseq = Integer.parseInt(words[0]);
+            k = Integer.parseInt(words[1]);
+            p = Integer.parseInt(words[2]);
 
             String line = null;
             while ((line = input.readLine()) != null) {
                 words = line.split(" ");
-                int seqid = Integer.valueOf(words[0]);
-                int pos = Integer.valueOf(words[1]);
-                int len = Integer.valueOf(words[2]);
+                int seqid = Integer.parseInt(words[0]);
+                int pos = Integer.parseInt(words[1]);
+                int len = Integer.parseInt(words[2]);
                 
                 if (dataset.attributes == null) {
                     dataset.attributes = new Attribute[len];

--- a/data/src/main/java/smile/data/parser/ArffParser.java
+++ b/data/src/main/java/smile/data/parser/ArffParser.java
@@ -501,7 +501,7 @@ public class ArffParser {
             
             String s = tokenizer.sval.trim();
             if (index < 0) {
-                index = Integer.valueOf(s);
+                index = Integer.parseInt(s);
                 if (index < 0 || index >= attributes.length) {
                     throw new ParseException("Invalid attribute index: " + index, tokenizer.lineno());
                 }

--- a/data/src/main/java/smile/data/parser/LibsvmParser.java
+++ b/data/src/main/java/smile/data/parser/LibsvmParser.java
@@ -147,10 +147,10 @@ public class LibsvmParser {
                 tokens = line.trim().split("\\s+");
 
                 if (classification) {
-                    int y = Integer.valueOf(tokens[0]);
+                    int y = Integer.parseInt(tokens[0]);
                     sparse.set(i, y);
                 } else {
-                    double y = Double.valueOf(tokens[0]);
+                    double y = Double.parseDouble(tokens[0]);
                     sparse.set(i, y);
                 }
 
@@ -160,8 +160,8 @@ public class LibsvmParser {
                         throw new NumberFormatException("Invalid data: " + tokens[k]);
                     }
 
-                    int j = Integer.valueOf(pair[0]) - 1;
-                    double x = Double.valueOf(pair[1]);
+                    int j = Integer.parseInt(pair[0]) - 1;
+                    double x = Double.parseDouble(pair[1]);
                     sparse.set(i, j, x);
                 }
 

--- a/data/src/main/java/smile/data/parser/SparseDatasetParser.java
+++ b/data/src/main/java/smile/data/parser/SparseDatasetParser.java
@@ -173,9 +173,9 @@ public class SparseDatasetParser {
                     throw new ParseException("Invalid number of tokens.", nrow);
                 }
 
-                int d = Integer.valueOf(tokens[0]) - arrayIndexOrigin;
-                int w = Integer.valueOf(tokens[1]) - arrayIndexOrigin;
-                double c = Double.valueOf(tokens[2]);
+                int d = Integer.parseInt(tokens[0]) - arrayIndexOrigin;
+                int w = Integer.parseInt(tokens[1]) - arrayIndexOrigin;
+                double c = Double.parseDouble(tokens[2]);
                 sparse.set(d, w, c);
 
                 line = reader.readLine();

--- a/data/src/main/java/smile/data/parser/SparseMatrixParser.java
+++ b/data/src/main/java/smile/data/parser/SparseMatrixParser.java
@@ -97,9 +97,9 @@ public class SparseMatrixParser {
             String[] tokens = line.split("\\s+");
             if (tokens.length == 3) {
                 try {
-                    nrows = Integer.valueOf(tokens[0]);
-                    ncols = Integer.valueOf(tokens[1]);
-                    n = Integer.valueOf(tokens[2]);        
+                    nrows = Integer.parseInt(tokens[0]);
+                    ncols = Integer.parseInt(tokens[1]);
+                    n = Integer.parseInt(tokens[2]);
                 } catch (Exception ex) {
                 }
             }
@@ -108,7 +108,7 @@ public class SparseMatrixParser {
                 // Harwell-Boeing Exchange Format. We ignore first two lines.
                 line = scanner.nextLine().trim();
                 tokens = line.split("\\s+");
-                int RHSCRD = Integer.valueOf(tokens[4]);
+                int RHSCRD = Integer.parseInt(tokens[4]);
 
                 line = scanner.nextLine().trim();
                 if (!line.startsWith("R")) {
@@ -116,9 +116,9 @@ public class SparseMatrixParser {
                 }
 
                 tokens = line.split("\\s+");
-                nrows = Integer.valueOf(tokens[1]);
-                ncols = Integer.valueOf(tokens[2]);
-                n = Integer.valueOf(tokens[3]);
+                nrows = Integer.parseInt(tokens[1]);
+                ncols = Integer.parseInt(tokens[2]);
+                n = Integer.parseInt(tokens[3]);
 
                 line = scanner.nextLine();
                 if (RHSCRD > 0) {

--- a/data/src/main/java/smile/data/parser/microarray/GCTParser.java
+++ b/data/src/main/java/smile/data/parser/microarray/GCTParser.java
@@ -168,8 +168,8 @@ public class GCTParser {
             throw new IOException("Invalid data size inforamation.");            
         }
         
-        int n = Integer.valueOf(tokens[0]);
-        int p = Integer.valueOf(tokens[1]);
+        int n = Integer.parseInt(tokens[0]);
+        int p = Integer.parseInt(tokens[1]);
         if (n <= 0 || p <= 0) {
             throw new IOException(String.format("Invalid data size %d x %d.", n, p));                        
         }

--- a/data/src/main/java/smile/data/parser/microarray/RESParser.java
+++ b/data/src/main/java/smile/data/parser/microarray/RESParser.java
@@ -187,7 +187,7 @@ public class RESParser {
             throw new IOException("Premature end of file.");
         }
 
-        int n = Integer.valueOf(line);
+        int n = Integer.parseInt(line);
         if (n <= 0) {
             throw new IOException("Invalid number of rows: " + n);            
         }

--- a/plot/src/main/java/smile/swing/table/IntegerArrayCellEditor.java
+++ b/plot/src/main/java/smile/swing/table/IntegerArrayCellEditor.java
@@ -75,7 +75,7 @@ public class IntegerArrayCellEditor extends DefaultCellEditor {
 
                 int[] data = new int[items.length];
                 for (int i = 0; i < data.length; i++) {
-                    data[i] = Integer.valueOf(items[i].trim());
+                    data[i] = Integer.parseInt(items[i].trim());
                 }
 
                 return data;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2130 - “ Parsing should be used to convert "Strings" to primitives”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2130
 
Please let me know if you have any questions.
Ayman Elkfrawy.