### PR TITLE
Fix: squid:S1149, Synchronized classes Vector, Hashtable, Stack and S…

### DIFF
--- a/demo/src/main/java/smile/demo/stat/distribution/ExponentialFamilyMixtureDemo.java
+++ b/demo/src/main/java/smile/demo/stat/distribution/ExponentialFamilyMixtureDemo.java
@@ -18,6 +18,8 @@ package smile.demo.stat.distribution;
 
 import java.awt.Color;
 import java.awt.GridLayout;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Vector;
 
 import javax.swing.JFrame;
@@ -57,7 +59,7 @@ public class ExponentialFamilyMixtureDemo extends JPanel {
         for (int i = 1000; i < 2000; i++)
             data[i] = gamma.rand();
 
-        Vector<Mixture.Component> m = new Vector<Mixture.Component>();
+        List<Mixture.Component> m = new ArrayList<>();
         Mixture.Component c = new Mixture.Component();
         c.priori = 0.25;
         c.distribution = new GaussianDistribution(0.0, 1.0);
@@ -114,7 +116,7 @@ public class ExponentialFamilyMixtureDemo extends JPanel {
         for (int i = 1000; i < 2000; i++)
             data[i] = gamma.rand();
 
-        Vector<Mixture.Component> m = new Vector<Mixture.Component>();
+        List<Mixture.Component> m = new ArrayList<>();
         Mixture.Component c = new Mixture.Component();
         c.priori = 0.25;
         c.distribution = new GaussianDistribution(0.0, 1.0);

--- a/math/src/test/java/smile/stat/distribution/ExponentialFamilyMixtureTest.java
+++ b/math/src/test/java/smile/stat/distribution/ExponentialFamilyMixtureTest.java
@@ -16,6 +16,8 @@
 
 package smile.stat.distribution;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Vector;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -71,7 +73,7 @@ public class ExponentialFamilyMixtureTest {
         for (int i = 1000; i < 2000; i++)
             data[i] = gamma.rand();
 
-        Vector<Mixture.Component> m = new Vector<Mixture.Component>();
+        List<Mixture.Component> m = new ArrayList<>();
         Mixture.Component c = new Mixture.Component();
         c.priori = 0.25;
         c.distribution = new GaussianDistribution(0.0, 1.0);

--- a/nlp/src/main/java/smile/nlp/NGram.java
+++ b/nlp/src/main/java/smile/nlp/NGram.java
@@ -57,7 +57,7 @@ public class NGram implements Comparable<NGram> {
 
     @Override
     public String toString() {
-    	StringBuffer sb = new StringBuffer();
+    	StringBuilder sb = new StringBuilder();
     	sb.append('(')
           .append(Arrays.toString(words))
           .append(", ")


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1149

 Please let me know if you have any questions.
Ayman Elkfrawy.