### PR TITLE
making RandomForest serializable

### DIFF
--- a/core/src/main/java/smile/classification/RandomForest.java
+++ b/core/src/main/java/smile/classification/RandomForest.java
@@ -79,7 +79,7 @@ public class RandomForest implements SoftClassifier<double[]>, Serializable {
      * tree on the OOB samples, which can be used when aggregating
      * tree votes.
      */
-    static class Tree {
+    static class Tree implements Serializable {
         DecisionTree tree;
         double weight;
         Tree(DecisionTree tree, double weight) {

--- a/data/src/main/java/smile/data/Attribute.java
+++ b/data/src/main/java/smile/data/Attribute.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package smile.data;
 
+import java.io.Serializable;
 import java.text.ParseException;
 
 /**
@@ -22,7 +23,7 @@ import java.text.ParseException;
  *
  * @author Haifeng Li
  */
-public abstract class Attribute {
+public abstract class Attribute implements Serializable {
     /**
      * The type of attributes.
      */


### PR DESCRIPTION
Right now the inner class `RandomForest$Tree` is not serializable, so I get the following when I try to save the model:

```
Caused by: java.io.NotSerializableException: smile.classification.RandomForest$Tree
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
```

This simple modification should make it work