### PR TITLE
ncol+attribute constructor for SparseDataset

### DIFF
--- a/data/src/main/java/smile/data/SparseDataset.java
+++ b/data/src/main/java/smile/data/SparseDataset.java
@@ -112,6 +112,17 @@ public class SparseDataset implements Iterable<Datum<SparseArray>> {
     }
 
     /**
+     * Constructor.
+     * @param ncols the number of columns in the matrix.
+     * @param response the attribute type of response variable.
+     */
+    public SparseDataset(int ncols, Attribute response) {
+        this.numColumns = ncols;
+        this.colSize = new int[ncols];
+        this.response = response; 
+    }
+
+    /**
      * Returns the dataset name.
      */
     public String getName() {


### PR DESCRIPTION
Sometimes I want to specify both the number of columns and the type of the response variable when creating a sparse dataset. This small patch solves this problem. 