### PR TITLE
Correct correctOutputError() method when the error function is cross error.

### DIFF
--- a/core/src/main/java/smile/classification/NeuralNetwork.java
+++ b/core/src/main/java/smile/classification/NeuralNetwork.java
@@ -706,6 +706,7 @@ public class NeuralNetwork implements OnlineClassifier<double[]>, SoftClassifier
             } else if (errorFunction == ErrorFunction.CROSS_ENTROPY) {
                 if (activationFunction == ActivationFunction.SOFTMAX) {
                     error -= output[i] * log(out);
+                    g *= -1.0;
                 } else if (activationFunction == ActivationFunction.LOGISTIC_SIGMOID) {
                     error = -output[i] * log(out) - (1.0 - output[i]) * log(1.0 - out);
                 }


### PR DESCRIPTION
![screenshot - 02112017 - 11 02 49 pm](https://cloud.githubusercontent.com/assets/10564070/22855838/9b94c924-f0ae-11e6-8237-9bab9d095236.png)

The partial derivative of cost function with respect to z is (output - target) rather than (target - output) in the case of cross entropy. 