### PR TITLE
Fix: KDTree RNNSearch now does not search in redundant nodes

### DIFF
--- a/core/src/main/java/smile/neighbor/KDTree.java
+++ b/core/src/main/java/smile/neighbor/KDTree.java
@@ -373,7 +373,7 @@ public class KDTree <E> implements NearestNeighborSearch<double[], E>, KNNSearch
             search(q, nearer, radius, neighbors);
 
             // now look in further half
-            if (radius >= diff * diff) {
+            if (radius >= Math.abs(diff)) {
                 search(q, further, radius, neighbors);
             }
         }


### PR DESCRIPTION
if `abs(diff) < 1`, then  `diff * diff < abs(diff)`, so we are visiting redundant nodes, because we need only nodes where distance from cutting plane is less than radius