### PR TITLE
Make methods in 'CooccurrenceKeywordExtractor' static

### DIFF
--- a/nlp/src/main/java/smile/nlp/keyword/CooccurrenceKeywordExtractor.java
+++ b/nlp/src/main/java/smile/nlp/keyword/CooccurrenceKeywordExtractor.java
@@ -54,7 +54,7 @@ public class CooccurrenceKeywordExtractor {
      * @param text A single document.
      * @return The top 10 keywords.
      */
-    public ArrayList<NGram> extract(String text) {
+    public static ArrayList<NGram> extract(String text) {
         return extract(text, 10);
     }
     
@@ -63,7 +63,7 @@ public class CooccurrenceKeywordExtractor {
      * @param text A single document.
      * @return The top keywords.
      */
-    public ArrayList<NGram> extract(String text, int maxNumKeywords) {
+    public static ArrayList<NGram> extract(String text, int maxNumKeywords) {
         ArrayList<String[]> sentences = new ArrayList<>();
         
         SimpleTokenizer tokenizer = new SimpleTokenizer();

--- a/nlp/src/test/java/smile/nlp/keyword/CooccurrenceKeywordExtractorTest.java
+++ b/nlp/src/test/java/smile/nlp/keyword/CooccurrenceKeywordExtractorTest.java
@@ -64,8 +64,7 @@ public class CooccurrenceKeywordExtractorTest {
         String text = scanner.useDelimiter("\\Z").next();
         scanner.close();
 
-        CooccurrenceKeywordExtractor instance = new CooccurrenceKeywordExtractor();
-        ArrayList<NGram> result = instance.extract(text);
+        ArrayList<NGram> result = CooccurrenceKeywordExtractor.extract(text);
         
         assertEquals(10, result.size());
         for (NGram ngram : result) {


### PR DESCRIPTION
Since the `CooccurrenceKeywordExtractor` doesn't have any instance variables and the operations do not depend on an instance creation, I think it makes sense to make its methods static.
It makes sense in terms of class design and it should have performance benefit (in theory at least).


