### PR TITLE
refine limit parameter value

### DIFF
--- a/data/src/main/java/smile/data/parser/DelimitedTextParser.java
+++ b/data/src/main/java/smile/data/parser/DelimitedTextParser.java
@@ -281,7 +281,7 @@ public class DelimitedTextParser {
             throw new IOException("Empty data source.");
         }
 
-        String[] s = line.split(delimiter, 0);
+        String[] s = line.split(delimiter, -1);
 
         if (attributes == null) {
             int p = s.length;


### PR DESCRIPTION
`0` value will trail empty string and shorten splitted array, then cause `s.length != ncols`