### PR TITLE
Explicit SBT version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16


### PR DESCRIPTION
Specify SBT version as a project property. 

That way, local updates won't break the compilation.