### PR TITLE
Ignoring some columns with DelimitedTextParser

### DIFF
--- a/data/src/main/java/smile/data/parser/DelimitedTextParser.java
+++ b/data/src/main/java/smile/data/parser/DelimitedTextParser.java
@@ -327,29 +327,29 @@ public class DelimitedTextParser {
 
         String[] s = line.split(delimiter, 0);
 
+        int p = s.length - ignoredColumns.size();
+
+        if (p <= 0) {
+          throw new IllegalArgumentException("There are more ignored columns (" + ignoredColumns.size() + ") than columns in the file (" + s.length + ").");
+        }
+
+        if (responseIndex >= s.length) {
+          throw new ParseException("Invalid response variable index: " + responseIndex, responseIndex);
+        }
+
+        if (ignoredColumns.contains(responseIndex)) {
+          throw new IllegalArgumentException("The response variable is present in the list of ignored columns.");
+        }
+
+        if (p == 1) {
+          throw new IllegalArgumentException("All columns are ignored, except the response variable.");
+        }
+
+        if (responseIndex >= 0) {
+          p--;
+        }
+
         if (attributes == null) {
-            int p = s.length - ignoredColumns.size();
-
-            if (p <= 0) {
-                throw new IllegalArgumentException("There are more ignored columns (" + ignoredColumns.size() + ") than columns in the file (" + s.length + ").");
-            }
-
-            if (responseIndex >= s.length) {
-                throw new ParseException("Invalid response variable index: " + responseIndex, responseIndex);
-            }
-
-            if (ignoredColumns.contains(responseIndex)) {
-                throw new IllegalArgumentException("The response variable is present in the list of ignored columns.");
-            }
-
-            if (p == 1) {
-                throw new IllegalArgumentException("All columns are ignored, except the response variable.");
-            }
-
-            if (responseIndex >= 0) {
-                p--;
-            }
-
             attributes = new Attribute[p];
             for (int i = 0, k = 0; i < s.length; i++) {
                 if (!ignoredColumns.contains(i) && i != responseIndex) {

--- a/data/src/main/java/smile/data/parser/DelimitedTextParser.java
+++ b/data/src/main/java/smile/data/parser/DelimitedTextParser.java
@@ -360,10 +360,6 @@ public class DelimitedTextParser {
 
         int ncols = attributes.length;
 
-        if (hasRowNames) {
-            ncols++;
-        }
-
         if (responseIndex >= 0) {
             ncols++;
         }

--- a/data/src/main/java/smile/data/parser/DelimitedTextParser.java
+++ b/data/src/main/java/smile/data/parser/DelimitedTextParser.java
@@ -25,6 +25,8 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.text.ParseException;
 
+import java.util.ArrayList;
+import java.util.List;
 import smile.data.Attribute;
 import smile.data.AttributeDataset;
 import smile.data.NumericAttribute;
@@ -71,6 +73,10 @@ public class DelimitedTextParser {
      * The column index of dependent/response variable.
      */
     private int responseIndex = -1;
+    /**
+     * Indices of columns to ignore
+     */
+    private List<Integer> ignoredColumns = new ArrayList<>();
 
     /**
      * Constructor with default delimiter of white space, comment line
@@ -137,6 +143,31 @@ public class DelimitedTextParser {
         this.responseIndex = index;
         return this;
     }
+
+    /**
+     * Sets the list of column indices to ignore (starting at 0)
+     */
+    public DelimitedTextParser setIgnoredColumns(List<Integer> ignoredColumns) {
+        this.ignoredColumns = ignoredColumns;
+        return this;
+    }
+
+    /**
+     * Adds one columns index to ignore
+     */
+    public DelimitedTextParser addIgnoredColumn(int index) {
+        this.ignoredColumns.add(index);
+        return this;
+    }
+
+    /**
+     * Adds several column indices to ignore
+     */
+    public DelimitedTextParser addIgnoredColumns(List<Integer> ignoredColumns) {
+        this.ignoredColumns.addAll(ignoredColumns);
+        return this;
+    }
+
 
     /**
      * Returns if the dataset has row names (at column 0).
@@ -290,16 +321,29 @@ public class DelimitedTextParser {
             throw new IOException("Empty data source.");
         }
 
+        if (hasRowNames) {
+            addIgnoredColumn(0);
+        }
+
         String[] s = line.split(delimiter, 0);
 
         if (attributes == null) {
-            int p = s.length;
-            if (hasRowNames) {
-                p--;
+            int p = s.length - ignoredColumns.size();
+
+            if (p <= 0) {
+                throw new IllegalArgumentException("There are more ignored columns (" + ignoredColumns.size() + ") than columns in the file (" + s.length + ").");
             }
 
             if (responseIndex >= s.length) {
                 throw new ParseException("Invalid response variable index: " + responseIndex, responseIndex);
+            }
+
+            if (ignoredColumns.contains(responseIndex)) {
+                throw new IllegalArgumentException("The response variable is present in the list of ignored columns.");
+            }
+
+            if (p == 1) {
+                throw new IllegalArgumentException("All columns are ignored, except the response variable.");
             }
 
             if (responseIndex >= 0) {
@@ -307,22 +351,24 @@ public class DelimitedTextParser {
             }
 
             attributes = new Attribute[p];
-            for (int i = 0; i < p; i++) {
-                attributes[i] = new NumericAttribute("V" + (i + 1));
+            for (int i = 0, k = 0; i < s.length; i++) {
+                if (!ignoredColumns.contains(i) && i != responseIndex) {
+                    attributes[k++] = new NumericAttribute("V" + (i + 1));
+                }
             }
         }
 
         int ncols = attributes.length;
-        int startColumn = 0;
 
         if (hasRowNames) {
             ncols++;
-            startColumn = 1;
         }
 
         if (responseIndex >= 0) {
             ncols++;
         }
+
+        ncols += ignoredColumns.size();
 
         if (ncols != s.length)
             throw new ParseException(String.format("%d columns, expected %d", s.length, ncols), s.length);
@@ -330,11 +376,13 @@ public class DelimitedTextParser {
         AttributeDataset data = new AttributeDataset(name, attributes, response);
 
         if (hasColumnNames) {
-            for (int i = startColumn, k = 0; i < s.length; i++) {
-                if (i != responseIndex) {
-                    attributes[k++].setName(s[i]);
-                } else {
-                    response.setName(s[i]);
+            for (int i = 0, k = 0; i < s.length; i++) {
+                if (!ignoredColumns.contains(i)) {
+                    if (i != responseIndex) {
+                        attributes[k++].setName(s[i]);
+                    } else {
+                        response.setName(s[i]);
+                    }
                 }
             }
         } else {
@@ -342,14 +390,16 @@ public class DelimitedTextParser {
             double[] x = new double[attributes.length];
             double y = Double.NaN;
 
-            for (int i = startColumn, k = 0; i < s.length; i++) {
-                if (i == responseIndex) {
-                    y = response.valueOf(s[i]);
-                } else if (missing != null && missing.equalsIgnoreCase(s[i])) {
-                    x[k++] = Double.NaN;
-                } else {
-                    x[k] = attributes[k].valueOf(s[i]);
-                    k++;
+            for (int i = 0, k = 0; i < s.length; i++) {
+                if (!ignoredColumns.contains(i)) {
+                    if (i == responseIndex) {
+                        y = response.valueOf(s[i]);
+                    } else if (missing != null && missing.equalsIgnoreCase(s[i])) {
+                        x[k++] = Double.NaN;
+                    } else {
+                        x[k] = attributes[k].valueOf(s[i]);
+                        k++;
+                    }
                 }
             }
 
@@ -371,14 +421,16 @@ public class DelimitedTextParser {
             double[] x = new double[attributes.length];
             double y = Double.NaN;
 
-            for (int i = startColumn, k = 0; i < s.length; i++) {
-                if (i == responseIndex) {
-                    y = response.valueOf(s[i]);
-                } else if (missing != null && missing.equalsIgnoreCase(s[i])) {
-                    x[k++] = Double.NaN;
-                } else {
-                    x[k] = attributes[k].valueOf(s[i]);
-                    k++;
+            for (int i = 0, k = 0; i < s.length; i++) {
+                if (!ignoredColumns.contains(i)) {
+                    if (i == responseIndex) {
+                        y = response.valueOf(s[i]);
+                    } else if (missing != null && missing.equalsIgnoreCase(s[i])) {
+                        x[k++] = Double.NaN;
+                    } else {
+                        x[k] = attributes[k].valueOf(s[i]);
+                        k++;
+                    }
                 }
             }
 

--- a/data/src/test/java/smile/data/parser/DelimitedTextParserTest.java
+++ b/data/src/test/java/smile/data/parser/DelimitedTextParserTest.java
@@ -15,8 +15,12 @@
  *******************************************************************************/
 package smile.data.parser;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -84,6 +88,49 @@ public class DelimitedTextParserTest {
             assertEquals(1.0000, x[7290][6], 1E-7);
         } catch (Exception ex) {
             System.err.println(ex);
+            Assert.fail();
+        }
+    }
+
+    /**
+     * Test of parse method, of class DelimitedTextParser, with some ignored columns.
+     */
+    @Test
+    public void testParseWithIgnoredColumns() throws Exception {
+        System.out.println("parse");
+        try {
+            List<Integer> ignoredColumns = new ArrayList<>();
+            ignoredColumns.add(6);
+            ignoredColumns.add(8);
+            DelimitedTextParser parser = new DelimitedTextParser();
+            parser.setResponseIndex(new NominalAttribute("class"), 0);
+            parser.setIgnoredColumns(ignoredColumns);
+            AttributeDataset usps = parser.parse("USPS Train", new File("C:\\Utilisateurs\\A665760\\projects\\smile\\shell\\src\\universal\\data\\usps\\zip.train"));
+            double[][] x = usps.toArray(new double[usps.size()][]);
+            int[] y = usps.toArray(new int[usps.size()]);
+
+            assertEquals(Attribute.Type.NOMINAL, usps.responseAttribute().getType());
+            for (Attribute attribute : usps.attributes()) {
+                assertEquals(Attribute.Type.NUMERIC, attribute.getType());
+            }
+
+            assertEquals(7291, usps.size());
+            assertEquals(256 - ignoredColumns.size(), usps.attributes().length);
+
+            assertEquals("6", usps.responseAttribute().toString(y[0]));
+            assertEquals("5", usps.responseAttribute().toString(y[1]));
+            assertEquals("4", usps.responseAttribute().toString(y[2]));
+            assertEquals(0.8620, x[0][6], 1E-7);
+            assertEquals(-0.1670, x[0][7], 1E-7);
+            assertEquals(-1.0000, x[0][8], 1E-7);
+
+            assertEquals("1", usps.responseAttribute().toString(y[7290]));
+            assertEquals(-1.0000, x[7290][4], 1E-7);
+            assertEquals(1.0000, x[7290][5], 1E-7);
+            assertEquals(-0.8670, x[7290][6], 1E-7);
+        } catch (Exception ex) {
+            System.err.println(ex);
+            Assert.fail();
         }
     }
 }

--- a/data/src/test/java/smile/data/parser/DelimitedTextParserTest.java
+++ b/data/src/test/java/smile/data/parser/DelimitedTextParserTest.java
@@ -105,7 +105,7 @@ public class DelimitedTextParserTest {
             DelimitedTextParser parser = new DelimitedTextParser();
             parser.setResponseIndex(new NominalAttribute("class"), 0);
             parser.setIgnoredColumns(ignoredColumns);
-            AttributeDataset usps = parser.parse("USPS Train", new File("C:\\Utilisateurs\\A665760\\projects\\smile\\shell\\src\\universal\\data\\usps\\zip.train"));
+            AttributeDataset usps = parser.parse("USPS Train", smile.data.parser.IOUtils.getTestDataFile("usps/zip.train"));
             double[][] x = usps.toArray(new double[usps.size()][]);
             int[] y = usps.toArray(new int[usps.size()]);
 


### PR DESCRIPTION
Adds the possibility to ignore some columns with DelimitedTextParser. By default, all columns are read. You can add column indices to ignore with the methods `setIgnoredColumns`, `addIgnoredColumn` and `addIgnoredColumns`. If `hasRowNames` is true, the first column is ignored. The response variable cannot be ignored.