### PR TITLE
Add additional constructor to CrossValidation

### DIFF
--- a/core/src/main/java/smile/validation/CrossValidation.java
+++ b/core/src/main/java/smile/validation/CrossValidation.java
@@ -52,6 +52,16 @@ public class CrossValidation {
      * @param k the number of rounds of cross validation.
      */
     public CrossValidation(int n, int k) {
+        this(n, k, true);
+    }
+    
+    /**
+     * Constructor.
+     * @param n the number of samples.
+     * @param k the number of rounds of cross validation.
+     * @param permutate determiner of index permutation
+     */
+    public CrossValidation(int n, int k, boolean permutate) {
         if (n < 0) {
             throw new IllegalArgumentException("Invalid sample size: " + n);
         }
@@ -62,7 +72,16 @@ public class CrossValidation {
 
         this.k = k;
 
-        int[] index = Math.permutate(n);
+        int[] index;
+        if (permutate){
+            index = Math.permutate(n);
+        }
+        else{
+            index = new int[n];
+            for (int i = 0; i < n; i++) {
+                index[i] = i;
+            }
+        }
 
         train = new int[k][];
         test = new int[k][];


### PR DESCRIPTION
Add additional constructor to CrossValidation so users can choose if they don't want the indices to be permutated.