### PR TITLE
Add support for attribute weights in regression Random Forest

### DIFF
--- a/core/src/main/java/smile/regression/RegressionTree.java
+++ b/core/src/main/java/smile/regression/RegressionTree.java
@@ -585,6 +585,9 @@ public class RegressionTree implements Regression<double[]>, Serializable {
                 throw new IllegalStateException("Unsupported attribute type: " + attributes[j].getType());
             }
 
+            double attributeWeight = attributes[j].getWeight();
+            split.splitScore *= attributeWeight;
+
             return split;
         }
     


### PR DESCRIPTION
I just multiply split score by attribute weight