### PR TITLE
Working around RNG issues with UniversalGenerator

### DIFF
--- a/math/src/main/java/smile/math/Random.java
+++ b/math/src/main/java/smile/math/Random.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2010 Haifeng Li
- *   
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -16,13 +16,13 @@
 
 package smile.math;
 
+import smile.math.random.MersenneTwister;
 import smile.math.random.RandomNumberGenerator;
-import smile.math.random.UniversalGenerator;
 
 /**
  * This is a high quality random number generator as a replacement of
  * the standard Random class of Java system.
- * 
+ *
  * @author Haifeng Li
  */
 public class Random {
@@ -33,14 +33,14 @@ public class Random {
      * Initialize with default random number generator engine.
      */
     public Random() {
-        this(new UniversalGenerator());
+        this(new MersenneTwister());
     }
 
     /**
      * Initialize with given seed for default random number generator engine.
      */
     public Random(long seed) {
-        this(new UniversalGenerator(seed));
+        this(new MersenneTwister(seed));
     }
 
     /**
@@ -52,6 +52,7 @@ public class Random {
 
     /**
      * Generator a random number uniformly distributed in [0, 1).
+     *
      * @return a pseudo random number
      */
     public double nextDouble() {
@@ -60,6 +61,7 @@ public class Random {
 
     /**
      * Generate n uniform random numbers in the range [0, 1)
+     *
      * @param d array of random numbers to be generated
      */
     public void nextDoubles(double[] d) {
@@ -68,6 +70,7 @@ public class Random {
 
     /**
      * Generate a uniform random number in the range [lo, hi)
+     *
      * @param lo lower limit of range
      * @param hi upper limit of range
      * @return a uniform random real in the range [lo, hi)
@@ -78,14 +81,15 @@ public class Random {
 
     /**
      * Generate n uniform random numbers in the range [lo, hi)
+     *
      * @param lo lower limit of range
      * @param hi upper limit of range
-     * @param d array of random numbers to be generated
+     * @param d  array of random numbers to be generated
      */
     public void nextDoubles(double[] d, double lo, double hi) {
         rng.nextDoubles(d);
 
-        double l = hi - lo;        
+        double l = hi - lo;
         int n = d.length;
         for (int i = 0; i < n; i++) {
             d[i] = lo + l * d[i];
@@ -105,7 +109,7 @@ public class Random {
     public int nextInt() {
         return rng.nextInt();
     }
-    
+
     /**
      * Returns a random integer in [0, n).
      */

--- a/math/src/main/java/smile/math/random/MersenneTwister.java
+++ b/math/src/main/java/smile/math/random/MersenneTwister.java
@@ -75,7 +75,7 @@ public class MersenneTwister implements RandomNumberGenerator {
 
     @Override
     public void setSeed(long seed) {
-        setSeed(seed % UniversalGenerator.BIG_PRIME);
+        setSeed((int)seed % UniversalGenerator.BIG_PRIME);
     }
 
     public void setSeed(int seed) {

--- a/math/src/main/java/smile/math/random/MersenneTwister.java
+++ b/math/src/main/java/smile/math/random/MersenneTwister.java
@@ -69,7 +69,7 @@ public class MersenneTwister implements RandomNumberGenerator {
     /**
      * Constructor.
      */
-    public MersenneTwister(int seed) {
+    public MersenneTwister(long seed) {
         setSeed(seed);
     }
 


### PR DESCRIPTION
### TL:DR 

If you are unlucky, your random forest will use at most ~10 datapoints from train set.

### Diving into the source code

I was debugging random forest that would not fit my train data.

Using break-points I noticed something very suspicious. 

https://github.com/haifengl/smile/blob/554b85cef4b7520c3483a2e4739bebaf9559e398/core/src/main/java/smile/regression/RandomForest.java#L292

After this loop `samples` array had mostly zeros, and only some indices had unusual high values. It was clear that random index was not so random.

I noticed, that the only random numbers for incides I got were: {63,64,127,128}. It looks like some kind of bit-operation issues.

Now, after debugging I have simple repro. Just run this code:

```
public class UniversalGeneratorBug {

    public static void main(String[] args) {
        UniversalGenerator random = new UniversalGenerator();

        HashSet<Integer> uniqueNumbers = new HashSet<>();
        for (int i = 0; i < 100000; i++) {
            uniqueNumbers.add(random.nextInt(320));
        }

        for (Integer num : uniqueNumbers) {
            System.out.println(num);
        }
    }

}
```
It will print:
```
128
256
192
0
64
319
255
191
127
63
```

Only 10 unique numbers from range 0-320! Certainly not random.

#### Some more observations

I noticed that nextInt() results will always have all least significant bits set all to 0 or all to 1. 

In my case 320 = 256 + 64. 

I guess this introduces some symmetry that results in regular outputs from RNG.

#### Workaround

I switched default implementation to MersenneTwister. I checked that Mersenne Twister does not suffer from this issue.

Also fixed some infinite recursion that will result in StackOverflow when called
