### PR TITLE
Support missing values in decision and regression tree

### DIFF
--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -329,7 +329,7 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
                         return falseChild.predict(x);
                     }
                 } else if (attributes[splitFeature].getType() == Attribute.Type.NUMERIC) {
-                    if (x[splitFeature] <= splitValue) {
+                    if (!(Double.isNaN(x[splitFeature]) && Double.isNaN(splitValue)) || x[splitFeature] <= splitValue) {
                         return trueChild.predict(x);
                     } else {
                         return falseChild.predict(x);
@@ -355,7 +355,7 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
                         return falseChild.predict(x, posteriori);
                     }
                 } else if (attributes[splitFeature].getType() == Attribute.Type.NUMERIC) {
-                    if (Double.isNaN(x[splitFeature]) && Double.isNaN(splitValue) || x[splitFeature] <= splitValue) {
+                    if (!(Double.isNaN(x[splitFeature]) && Double.isNaN(splitValue)) || x[splitFeature] <= splitValue) {
                         return trueChild.predict(x, posteriori);
                     } else {
                         return falseChild.predict(x, posteriori);
@@ -534,8 +534,6 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
                         }
                     }
                 } catch (Exception ex) {
-                    // TODO: what is that for?
-                    // if there is no MulticoreExecutor
                     for (int j = 0; j < mtry; j++) {
                         Node split = findBestSplit(n, count, falseCount, impurity, variables[j]);
                         if (split.splitScore > node.splitScore) {

--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -967,10 +967,28 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
 
             for (int j = 0; j < p; j++) {
                 if (attributes[j] instanceof NumericAttribute) {
+                    // is it ok to use ArrayList here?
+                    List<Integer> nans = new ArrayList<>();
+                    int nonNanCount = 0;
                     for (int i = 0; i < n; i++) {
-                        a[i] = x[i][j];
+                        if (!Double.isNaN(x[i][j])) {
+                            a[i] = x[i][j];
+                            nonNanCount++;
+                        } else {
+                            // Question: should we put NaN values in the end of the sorting
+                            // or at the start ? (change the sign value of the MAX_VALUE)
+                            // what difference will make it?
+                            a[i] = Double.MAX_VALUE;
+                            nans.add(i);
+                        }
                     }
                     this.order[j] = QuickSort.sort(a);
+                    // fill the rest with non-comparable NaN values
+                    for (int nanIndex = 0; nanIndex < nans.size(); nanIndex++) {
+                        int globalIndex = nonNanCount + nanIndex;
+                        this.order[j][globalIndex] = nans.get(nanIndex);
+                    }
+                    
                 }
             }
         }

--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -444,8 +444,8 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
         }
 
         /**
-		 * check if all of the samples
-		 * has the same label
+		 * Check if all of the samples
+		 * have the same label
          */
         public boolean isPure() {
             int label = -1;
@@ -977,7 +977,6 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
 
             for (int j = 0; j < p; j++) {
                 if (attributes[j] instanceof NumericAttribute) {
-                    // is it ok to use ArrayList here?
                     List<Integer> nans = new ArrayList<>();
                     int nonNanCount = 0;
                     for (int i = 0; i < n; i++) {

--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -683,18 +683,37 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
                     }
                 }
             } else if (attributes[node.splitFeature].getType() == Attribute.Type.NUMERIC) {
+                List<Integer> nanIndexes = new ArrayList<>();
                 for (int i = 0; i < n; i++) {
                     if (samples[i] > 0) {
-                        if (x[i][node.splitFeature] <= node.splitValue) {
+                        if (Double.isNaN(node.splitValue) && Double.isNaN(x[i][node.splitFeature])) {
                             trueSamples[i] = samples[i];
                             tc += trueSamples[i];
                             samples[i] = 0;
-                        } else {
+                        } else if (x[i][node.splitFeature] <= node.splitValue) {
+                            trueSamples[i] = samples[i];
+                            tc += trueSamples[i];
+                            samples[i] = 0;
+                        } else if (!Double.isNaN(x[i][node.splitFeature])) {
                             //falseSamples[i] = samples[i];
                             fc += samples[i];
+                        } else {
+                            nanIndexes.add(i);
                         }
                     }
                 }
+                if (tc > fc) {
+                    for (int i : nanIndexes) {
+                        trueSamples[i] = samples[i];
+                        tc += trueSamples[i];
+                        samples[i] = 0;
+                    }
+                } else {
+                    for (int i : nanIndexes) {
+                        fc += samples[i];
+                    }
+                }
+                
             } else {
                 throw new IllegalStateException("Unsupported attribute type: " + attributes[node.splitFeature].getType());
             }

--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -684,21 +684,28 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
                 }
             } else if (attributes[node.splitFeature].getType() == Attribute.Type.NUMERIC) {
                 List<Integer> nanIndexes = new ArrayList<>();
-                for (int i = 0; i < n; i++) {
-                    if (samples[i] > 0) {
-                        if ((Double.isNaN(node.splitValue) && Double.isNaN(x[i][node.splitFeature]))
-								|| x[i][node.splitFeature] <= node.splitValue) {
-                            trueSamples[i] = samples[i];
-                            tc += trueSamples[i];
-                            samples[i] = 0;
-                        } else if (!Double.isNaN(x[i][node.splitFeature])) {
-                            //falseSamples[i] = samples[i];
-                            fc += samples[i];
-                        } else {
-                            nanIndexes.add(i);
-                        }
-                    }
-                }
+				boolean isSplitValueNaN = Double.isNaN(node.splitValue);
+				for (int i = 0; i < n; i++) {
+					if(isSplitValueNaN) {
+						if(!Double.isNaN(x[i][node.splitFeature])){
+							trueSamples[i] = samples[i];
+							tc += trueSamples[i];
+							samples[i] = 0;
+						} else {
+							fc += samples[i];
+						}
+					} else {
+						if(Double.isNaN(x[i][node.splitFeature])) {
+							nanIndexes.add(i);
+						} else if(x[i][node.splitFeature] <= node.splitValue) {
+							trueSamples[i] = samples[i];
+							tc += trueSamples[i];
+							samples[i] = 0;
+						} else {
+							fc += samples[i];
+						}
+					}
+				}
                 if (tc > fc) {
                     for (int i : nanIndexes) {
                         trueSamples[i] = samples[i];

--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -114,7 +114,7 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
     /**
      * The root of the regression tree
      */
-    private Node root;
+    public Node root;
     /**
      * The splitting rule.
      */
@@ -445,10 +445,10 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
         }
 
         /**
-         * Finds the best attribute to split on at the current node. Returns
-         * true if a split exists to reduce squared error, false otherwise.
+		 * check if all of the samples
+		 * has the same label
          */
-        public boolean findBestSplit() {
+        public boolean isPure() {
             int label = -1;
             boolean pure = true;
             for (int i = 0; i < x.length; i++) {
@@ -589,6 +589,7 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
 
                     int trueLabel = Math.whichMax(trueCount[l]);
                     int falseLabel = Math.whichMax(falseCount);
+					double gain = impurity - (double) tc / n * impurity(trueCount[l], tc) - (double) fc / n * impurity(falseCount, fc);
 
                     if (gain > splitNode.splitScore) {
                         // new best split

--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -18,7 +18,6 @@ package smile.classification;
 import java.io.Serializable;
 import java.util.*;
 import java.util.concurrent.Callable;
-import java.util.Map.Entry;
 
 import smile.data.Attribute;
 import smile.data.NominalAttribute;
@@ -280,7 +279,7 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
         /**
          * The split value.
          */
-        double splitValue = Double.NaN;
+        double splitValue = Double.MIN_VALUE;
         /**
          * Reduction in splitting criterion.
          */
@@ -356,7 +355,7 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
                         return falseChild.predict(x, posteriori);
                     }
                 } else if (attributes[splitFeature].getType() == Attribute.Type.NUMERIC) {
-                    if (x[splitFeature] <= splitValue) {
+                    if (Double.isNaN(x[splitFeature]) && Double.isNaN(splitValue) || x[splitFeature] <= splitValue) {
                         return trueChild.predict(x, posteriori);
                     } else {
                         return falseChild.predict(x, posteriori);
@@ -687,11 +686,8 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
                 List<Integer> nanIndexes = new ArrayList<>();
                 for (int i = 0; i < n; i++) {
                     if (samples[i] > 0) {
-                        if (Double.isNaN(node.splitValue) && Double.isNaN(x[i][node.splitFeature])) {
-                            trueSamples[i] = samples[i];
-                            tc += trueSamples[i];
-                            samples[i] = 0;
-                        } else if (x[i][node.splitFeature] <= node.splitValue) {
+                        if ((Double.isNaN(node.splitValue) && Double.isNaN(x[i][node.splitFeature]))
+								|| x[i][node.splitFeature] <= node.splitValue) {
                             trueSamples[i] = samples[i];
                             tc += trueSamples[i];
                             samples[i] = 0;
@@ -721,7 +717,7 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
 
             if (tc < nodeSize || fc < nodeSize) {
                 node.splitFeature = -1;
-                node.splitValue = Double.NaN;
+                node.splitValue = Double.MIN_VALUE;
                 node.splitScore = 0.0;
                 return false;
             }

--- a/core/src/main/java/smile/regression/RegressionTree.java
+++ b/core/src/main/java/smile/regression/RegressionTree.java
@@ -298,7 +298,7 @@ public class RegressionTree implements Regression<double[]>, Serializable {
                         return falseChild.predict(x);
                     }
                 } else if (attributes[splitFeature].getType() == Attribute.Type.NUMERIC) {
-                    if ((Double.isNaN(x[splitFeature] ) && Double.isNaN(splitValue)) || x[splitFeature] <= splitValue) {
+                    if (!((Double.isNaN(x[splitFeature]) && Double.isNaN(splitValue))) || x[splitFeature] <= splitValue) {
                         return trueChild.predict(x);
                     } else {
                         return falseChild.predict(x);

--- a/core/src/main/java/smile/regression/RegressionTree.java
+++ b/core/src/main/java/smile/regression/RegressionTree.java
@@ -621,20 +621,29 @@ public class RegressionTree implements Regression<double[]>, Serializable {
                 List<Integer> nanIndexes = new ArrayList<>();
                 for (int i = 0; i < n; i++) {
                     if (samples[i] > 0) {
-                        if ((Double.isNaN(node.splitValue) && Double.isNaN(x[i][node.splitFeature]))
-                                || x[i][node.splitFeature] <= node.splitValue) {
-                            trueSamples[i] = samples[i];
-                            tc += trueSamples[i];
-                            samples[i] = 0;
-                        } else if(!Double.isNaN(x[i][node.splitFeature])) {
-                            //falseSamples[i] = samples[i];
-                            fc += samples[i];
+                        boolean isSplitValueNaN = Double.isNaN(node.splitValue);
+                        if(isSplitValueNaN) {
+                            if(!Double.isNaN(x[i][node.splitFeature])){
+                                trueSamples[i] = samples[i];
+                                tc += trueSamples[i];
+                                samples[i] = 0;
+                            } else {
+                                fc += samples[i];
+                            }
                         } else {
-                            // put cases with NaN based on final true count and false count(whatever is higherˀ)
-                            nanIndexes.add(i);
+                            if(Double.isNaN(x[i][node.splitFeature])) {
+                                nanIndexes.add(i);
+                            } else if(x[i][node.splitFeature] <= node.splitValue) {
+                                trueSamples[i] = samples[i];
+                                tc += trueSamples[i];
+                                samples[i] = 0;
+                            } else {
+                                fc += samples[i];
+                            }
                         }
                     }
                 }
+                // put cases with NaN based on final true count and false count(whatever is higherˀ)
                 if(tc > fc) {
                     for(int i : nanIndexes) {
                         trueSamples[i] = samples[i];

--- a/core/src/test/java/smile/classification/DecisionTreeTest.java
+++ b/core/src/test/java/smile/classification/DecisionTreeTest.java
@@ -97,8 +97,6 @@ public class DecisionTreeTest {
         //Act
         DecisionTree tree = new DecisionTree(attributes, x, y, 3);
         
-        double[] importance = tree.importance();
-        
         //Assert
         assertEquals(Double.isNaN(tree.root.splitValue), true);
         

--- a/core/src/test/java/smile/classification/DecisionTreeTest.java
+++ b/core/src/test/java/smile/classification/DecisionTreeTest.java
@@ -58,13 +58,20 @@ public class DecisionTreeTest {
     
     
     @Test
-    public void nullTestImportance() {
+    public void testImportantFeatureWithNull() {
         
         //Arrange
         
         double[][] x =
-                { { 10D, Double.NaN }, { 20D, 1 }, { 10D, Double.NaN }, { 20D, 1 }, { 20D, 1 }, { 10D, Double.NaN },
-                        { 20D, Double.NaN } };
+			{
+				{ 10D, Double.NaN },
+				{ 20D, 1 },
+				{ 10D, Double.NaN },
+				{ 20D, 1 },
+				{ 20D, 1 },
+				{ 10D, Double.NaN },
+				{ 20D, Double.NaN }
+			};
         
         int[] y = { 1, 0, 1, 0, 0, 1, 1 };
         Attribute[] attributes = { new NumericAttribute("Feature A"), new NumericAttribute("Feature B") };
@@ -72,9 +79,6 @@ public class DecisionTreeTest {
         DecisionTree tree = new DecisionTree(attributes, x, y, 3);
         
         double[] importance = tree.importance();
-        for (int i = 0; i < importance.length; i++) {
-            System.out.println(importance[i]);
-        }
         
         //Assert
         assertEquals(importance[1] > importance[0], true);
@@ -83,14 +87,20 @@ public class DecisionTreeTest {
     
     
     @Test
-    public void nullTestRightRoot() {
+    public void testSplitValueNaN() {
         
         //Arrange
         
         double[][] x =
-                { { 10D, Double.NaN }, { 20D, 126 }, { 10D, Double.NaN }, { 20D, 78 }, { 20D, 156 },
-                        { 10D, Double.NaN },
-                        { 20D, Double.NaN } };
+			{
+				{ 10D, Double.NaN },
+				{ 20D, 126 },
+				{ 10D, Double.NaN },
+				{ 20D, 78 },
+				{ 20D, 156 },
+				{ 10D, Double.NaN },
+				{ 20D, Double.NaN }
+			};
         
         int[] y = { 1, 0, 1, 0, 0, 1, 1 };
         Attribute[] attributes = { new NumericAttribute("Feature A"), new NumericAttribute("Feature B") };

--- a/core/src/test/java/smile/classification/DecisionTreeTest.java
+++ b/core/src/test/java/smile/classification/DecisionTreeTest.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package smile.classification;
 
+import smile.data.NumericAttribute;
 import smile.sort.QuickSort;
 import smile.data.Attribute;
 import smile.data.NominalAttribute;
@@ -54,6 +55,55 @@ public class DecisionTreeTest {
     @After
     public void tearDown() {
     }
+    
+    
+    @Test
+    public void nullTestImportance() {
+        
+        //Arrange
+        
+        double[][] x =
+                { { 10D, Double.NaN }, { 20D, 1 }, { 10D, Double.NaN }, { 20D, 1 }, { 20D, 1 }, { 10D, Double.NaN },
+                        { 20D, Double.NaN } };
+        
+        int[] y = { 1, 0, 1, 0, 0, 1, 1 };
+        Attribute[] attributes = { new NumericAttribute("Feature A"), new NumericAttribute("Feature B") };
+        //Act
+        DecisionTree tree = new DecisionTree(attributes, x, y, 3);
+        
+        double[] importance = tree.importance();
+        for (int i = 0; i < importance.length; i++) {
+            System.out.println(importance[i]);
+        }
+        
+        //Assert
+        assertEquals(importance[1] > importance[0], true);
+        
+    }
+    
+    
+    @Test
+    public void nullTestRightRoot() {
+        
+        //Arrange
+        
+        double[][] x =
+                { { 10D, Double.NaN }, { 20D, 126 }, { 10D, Double.NaN }, { 20D, 78 }, { 20D, 156 },
+                        { 10D, Double.NaN },
+                        { 20D, Double.NaN } };
+        
+        int[] y = { 1, 0, 1, 0, 0, 1, 1 };
+        Attribute[] attributes = { new NumericAttribute("Feature A"), new NumericAttribute("Feature B") };
+        //Act
+        DecisionTree tree = new DecisionTree(attributes, x, y, 3);
+        
+        double[] importance = tree.importance();
+        
+        //Assert
+        assertEquals(Double.isNaN(tree.root.splitValue), true);
+        
+    }
+    
     
     /**
      * Test of learn method, of class DecisionTree.

--- a/core/src/test/java/smile/regression/RegressionTreeTest.java
+++ b/core/src/test/java/smile/regression/RegressionTreeTest.java
@@ -58,12 +58,20 @@ public class RegressionTreeTest {
     }
     
     @Test
-    public void nullTestImportance() {
+    public void testImportantFeatureWithNull() {
         
         //Arrange
         double[][] x =
-                { { 10D, 5}, { 10, 5}, { 20, 170}, { 20, 170}, { 20, 170}, { 50, 99},
-                        { 50, 99}, { 50, 99} };
+            {
+                { 10D, 5},
+                { 10, 5},
+                { 20, 170},
+                { 20, 170},
+                { 20, 170},
+                { 50, 99},
+                { 50, 99},
+                { 50, 99}
+            };
         
         double[] y = { 20, 20, 500, 500, 500, 100, 100, 100 };
         Attribute[] attributes = { new NumericAttribute("Feature A"), new NumericAttribute("Feature B") };
@@ -77,12 +85,20 @@ public class RegressionTreeTest {
         
     }
     @Test
-    public void nullTestImportanceCorrectRoot() {
+    public void testSplitValueNaN() {
 
         //Arrange
         double[][] x =
-                { { 10D, 5}, { 10, 5}, { 20, Double.NaN }, { 20, Double.NaN }, { 20, Double.NaN }, { Double.NaN , 99},
-                        { Double.NaN , 99}, { Double.NaN , 99} };
+            {
+                { 10D, 5},
+                { 10, 5},
+                { 20, Double.NaN },
+                { 20, Double.NaN },
+                { 20, Double.NaN },
+                { Double.NaN , 99},
+                { Double.NaN , 99},
+                { Double.NaN , 99}
+            };
 
         double[] y = { 20, 20, 500, 500, 500, 100, 100, 100 };
         Attribute[] attributes = { new NumericAttribute("Feature A"), new NumericAttribute("Feature B") };

--- a/core/src/test/java/smile/regression/RegressionTreeTest.java
+++ b/core/src/test/java/smile/regression/RegressionTreeTest.java
@@ -20,7 +20,9 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import smile.data.Attribute;
 import smile.data.AttributeDataset;
+import smile.data.NumericAttribute;
 import smile.data.parser.ArffParser;
 import smile.math.Math;
 import smile.sort.QuickSort;
@@ -53,6 +55,47 @@ public class RegressionTreeTest {
     
     @After
     public void tearDown() {
+    }
+    
+    @Test
+    public void nullTestImportance() {
+        
+        //Arrange
+        double[][] x =
+                { { 10D, 5}, { 10, 5}, { 20, 170}, { 20, 170}, { 20, 170}, { 50, 99},
+                        { 50, 99}, { 50, 99} };
+        
+        double[] y = { 20, 20, 500, 500, 500, 100, 100, 100 };
+        Attribute[] attributes = { new NumericAttribute("Feature A"), new NumericAttribute("Feature B") };
+        //Act
+        RegressionTree tree = new RegressionTree(attributes, x, y, 3, 2);
+        
+        double[] importance = tree.importance();
+        
+        //Assert
+        assertEquals(importance[1] > importance[0], true);
+        
+    }
+    @Test
+    public void nullTestImportanceCorrectRoot() {
+
+        //Arrange
+        double[][] x =
+                { { 10D, 5}, { 10, 5}, { 20, Double.NaN }, { 20, Double.NaN }, { 20, Double.NaN }, { Double.NaN , 99},
+                        { Double.NaN , 99}, { Double.NaN , 99} };
+
+        double[] y = { 20, 20, 500, 500, 500, 100, 100, 100 };
+        Attribute[] attributes = { new NumericAttribute("Feature A"), new NumericAttribute("Feature B") };
+        //Act
+        RegressionTree tree = new RegressionTree(attributes, x, y, 3, 2);
+
+        double[] importance = tree.importance();
+        for (int i = 0; i < importance.length; i++) {
+            System.out.println(importance[i]);
+        }
+
+        //Assert
+        assertEquals(Double.isNaN(tree.root.splitValue), true);
     }
 
     /**


### PR DESCRIPTION
Double.NaN is a representation of a missing value.
Double.NaN is replaced with Double.MIN_VALUE to act as an initial value.


Splitting:
* if splitValue is not NaN, then put all of the NaN value into the branch that has a higher amount of examples in it.
* if splitValue is NaN put all of NaNs into a true child and all of the others into false child
* this way of handling missing values is according to the recommendations of Breiman et.al (1984) and can be achieved in R(`rpart`) with passing `usesurrogate=2`.

Ordering numerical feature:
* NaN values will be last in the ordering. 

