### PR TITLE
Upgrade SBT and use https for resolvers

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.1.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.2")
 


### PR DESCRIPTION
It's a security issue to use http for a resolver. The jars you download could be switched out for malicious versions. See here: https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/