### PR TITLE
Add constructors taking AttributeDataset

### DIFF
--- a/core/src/main/java/smile/classification/AdaBoost.java
+++ b/core/src/main/java/smile/classification/AdaBoost.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import smile.data.Attribute;
+import smile.data.AttributeDataset;
 import smile.data.NumericAttribute;
 import smile.math.Math;
 import smile.util.SmileUtils;
@@ -204,6 +205,28 @@ public class AdaBoost implements SoftClassifier<double[]>, Serializable {
     public AdaBoost(Attribute[] attributes, double[][] x, int[] y, int ntrees) {
         this(attributes, x, y, ntrees, 2);
     }
+
+    /**
+     * Constructor. Learns AdaBoost with decision stumps.
+     *
+     * @param data the dataset
+     * @param ntrees the number of trees.
+     */
+    public AdaBoost(AttributeDataset data, int ntrees) {
+        this(data.attributes(), data.x(), data.labels(), ntrees);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param data the dataset
+     * @param ntrees the number of trees.
+     * @param maxNodes the maximum number of leaf nodes in the trees.
+     */
+    public AdaBoost(AttributeDataset data, int ntrees, int maxNodes) {
+        this(data.attributes(), data.x(), data.labels(), ntrees, maxNodes);
+    }
+
     /**
      * Constructor.
      *

--- a/core/src/main/java/smile/classification/GradientTreeBoost.java
+++ b/core/src/main/java/smile/classification/GradientTreeBoost.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 
 import smile.data.Attribute;
+import smile.data.AttributeDataset;
 import smile.data.NumericAttribute;
 import smile.math.Math;
 import smile.regression.RegressionTree;
@@ -283,6 +284,16 @@ public class GradientTreeBoost implements SoftClassifier<double[]>, Serializable
 
     /**
      * Constructor. Learns a gradient tree boosting for classification.
+     *
+     * @param data the dataset.
+     * @param ntrees the number of iterations (trees).
+     */
+    public GradientTreeBoost(AttributeDataset data, int ntrees) {
+        this(data.attributes(), data.x(), data.labels(), ntrees);
+    }
+
+    /**
+     * Constructor. Learns a gradient tree boosting for classification.
      * 
      * @param attributes the attribute properties.
      * @param x the training instances. 
@@ -292,7 +303,20 @@ public class GradientTreeBoost implements SoftClassifier<double[]>, Serializable
     public GradientTreeBoost(Attribute[] attributes, double[][] x, int[] y, int ntrees) {
         this(attributes, x, y, ntrees, 6, x.length < 2000 ? 0.005 : 0.05, 0.7);
     }
-    
+
+    /**
+     * Constructor. Learns a gradient tree boosting for classification.
+     *
+     * @param data the dataset.
+     * @param ntrees the number of iterations (trees).
+     * @param maxNodes the number of leaves in each tree.
+     * @param shrinkage the shrinkage parameter in (0, 1] controls the learning rate of procedure.
+     * @param subsample the sampling fraction for stochastic tree boosting.
+     */
+    public GradientTreeBoost(AttributeDataset data, int ntrees, int maxNodes, double shrinkage, double subsample) {
+        this(data.attributes(), data.x(), data.labels(), ntrees, maxNodes, shrinkage, subsample);
+    }
+
     /**
      * Constructor. Learns a gradient tree boosting for classification.
      *

--- a/core/src/main/java/smile/classification/RandomForest.java
+++ b/core/src/main/java/smile/classification/RandomForest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Callable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import smile.data.Attribute;
+import smile.data.AttributeDataset;
 import smile.data.NumericAttribute;
 import smile.math.Math;
 import smile.util.MulticoreExecutor;
@@ -454,6 +455,17 @@ public class RandomForest implements SoftClassifier<double[]>, Serializable {
     /**
      * Constructor. Learns a random forest for classification.
      *
+     * @param data the dataset
+     * @param ntrees the number of trees.
+     * generally good performance, where dim is the number of variables.
+     */
+    public RandomForest(AttributeDataset data, int ntrees) {
+        this(data.attributes(), data.x(), data.labels(), ntrees);
+    }
+    
+    /**
+     * Constructor. Learns a random forest for classification.
+     *
      * @param attributes the attribute properties.
      * @param x the training instances.
      * @param y the response variable.
@@ -465,6 +477,19 @@ public class RandomForest implements SoftClassifier<double[]>, Serializable {
     public RandomForest(Attribute[] attributes, double[][] x, int[] y, int ntrees, int mtry) {
         this(attributes, x, y, ntrees, 100, 5, mtry, 1.0);
 
+    }
+
+    /**
+     * Constructor. Learns a random forest for classification.
+     *
+     * @param data the dataset
+     * @param ntrees the number of trees.
+     * @param mtry the number of random selected features to be used to determine
+     * the decision at a node of the tree. floor(sqrt(dim)) seems to give
+     * generally good performance, where dim is the number of variables.
+     */
+    public RandomForest(AttributeDataset data, int ntrees, int mtry) {
+        this(data.attributes(), data.x(), data.labels(), ntrees, mtry);
     }
 
     /**
@@ -489,6 +514,24 @@ public class RandomForest implements SoftClassifier<double[]>, Serializable {
     /**
      * Constructor. Learns a random forest for classification.
      *
+     * @param data the dataset
+     * @param ntrees the number of trees.
+     * @param mtry the number of random selected features to be used to determine
+     * the decision at a node of the tree. floor(sqrt(dim)) seems to give
+     * generally good performance, where dim is the number of variables.
+     * @param nodeSize the minimum size of leaf nodes.
+     * @param maxNodes the maximum number of leaf nodes in the tree.
+     * @param subsample the sampling rate for training tree. 1.0 means sampling with replacement. < 1.0 means
+     *                  sampling without replacement.
+     * @param rule Decision tree split rule.
+     */
+    public RandomForest(AttributeDataset data, int ntrees, int maxNodes, int nodeSize, int mtry, double subsample, DecisionTree.SplitRule rule) {
+        this(data.attributes(), data.x(), data.labels(), ntrees, maxNodes, nodeSize, mtry, subsample, rule);
+    }
+
+    /**
+     * Constructor. Learns a random forest for classification.
+     *
      * @param attributes the attribute properties.
      * @param x the training instances.
      * @param y the response variable.
@@ -504,6 +547,31 @@ public class RandomForest implements SoftClassifier<double[]>, Serializable {
      */
     public RandomForest(Attribute[] attributes, double[][] x, int[] y, int ntrees, int maxNodes, int nodeSize, int mtry, double subsample, DecisionTree.SplitRule rule) {
         this(attributes, x, y, ntrees, maxNodes, nodeSize, mtry, subsample, rule, null);
+    }
+
+    /**
+     * Constructor. Learns a random forest for classification.
+     *
+     * @param data the dataset
+     * @param ntrees the number of trees.
+     * @param mtry the number of random selected features to be used to determine
+     * the decision at a node of the tree. floor(sqrt(dim)) seems to give
+     * generally good performance, where dim is the number of variables.
+     * @param nodeSize the minimum size of leaf nodes.
+     * @param maxNodes the maximum number of leaf nodes in the tree.
+     * @param subsample the sampling rate for training tree. 1.0 means sampling with replacement. < 1.0 means
+     *                  sampling without replacement.
+     * @param rule Decision tree split rule.
+     * @param classWeight Priors of the classes. The weight of each class
+     *                    is roughly the ratio of samples in each class.
+     *                    For example, if
+     *                    there are 400 positive samples and 100 negative
+     *                    samples, the classWeight should be [1, 4]
+     *                    (assuming label 0 is of negative, label 1 is of
+     *                    positive).
+     */
+    public RandomForest(AttributeDataset data, int ntrees, int maxNodes, int nodeSize, int mtry, double subsample, DecisionTree.SplitRule rule, int[] classWeight) {
+        this(data.attributes(), data.x(), data.labels(), ntrees, maxNodes, nodeSize, mtry, subsample, rule, classWeight);
     }
 
     /**

--- a/core/src/main/java/smile/regression/GradientTreeBoost.java
+++ b/core/src/main/java/smile/regression/GradientTreeBoost.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 
 import smile.data.Attribute;
+import smile.data.AttributeDataset;
 import smile.data.NumericAttribute;
 import smile.math.Math;
 import smile.sort.QuickSelect;
@@ -321,13 +322,36 @@ public class GradientTreeBoost implements Regression<double[]>, Serializable {
     public GradientTreeBoost(Attribute[] attributes, double[][] x, double[] y, int ntrees) {
         this(attributes, x, y, Loss.LeastAbsoluteDeviation, ntrees, 6, x.length < 2000 ? 0.005 : 0.05, 0.7);
     }
-    
+
     /**
      * Constructor. Learns a gradient tree boosting for regression.
      *
-     * @param attributes the attribute properties.
-     * @param x the training instances. 
-     * @param y the response variable.
+     * @param data the dataset.
+     * @param ntrees the number of iterations (trees).
+     */
+    public GradientTreeBoost(AttributeDataset data, int ntrees) {
+        this(data.attributes(), data.x(), data.y(), ntrees);
+    }
+
+    /**
+     * Constructor. Learns a gradient tree boosting for regression.
+     *
+     * @param data the dataset.
+     * @param loss loss function for regression. By default, least absolute
+     * deviation is employed for robust regression.
+     * @param ntrees the number of iterations (trees).
+     * @param maxNodes the number of leaves in each tree.
+     * @param shrinkage the shrinkage parameter in (0, 1] controls the learning rate of procedure.
+     * @param f the sampling fraction for stochastic tree boosting.
+     */
+    public GradientTreeBoost(AttributeDataset data, Loss loss, int ntrees, int maxNodes, double shrinkage, double f) {
+        this(data.attributes(), data.x(), data.y(), loss, ntrees, maxNodes, shrinkage, f);
+    }
+
+    /**
+     * Constructor. Learns a gradient tree boosting for regression.
+     *
+     * @param data the dataset.
      * @param loss loss function for regression. By default, least absolute
      * deviation is employed for robust regression.
      * @param ntrees the number of iterations (trees).

--- a/core/src/main/java/smile/regression/RandomForest.java
+++ b/core/src/main/java/smile/regression/RandomForest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 import smile.data.Attribute;
+import smile.data.AttributeDataset;
 import smile.data.NumericAttribute;
 import smile.math.Math;
 import smile.util.MulticoreExecutor;
@@ -379,6 +380,16 @@ public class RandomForest implements Regression<double[]>, Serializable {
     /**
      * Constructor. Learns a random forest for regression.
      *
+     * @param data the dataset
+     * @param ntrees the number of trees.
+     */
+    public RandomForest(AttributeDataset data, int ntrees) {
+        this(data.attributes(), data.x(), data.y(), ntrees);
+    }    
+
+    /**
+     * Constructor. Learns a random forest for regression.
+     *
      * @param attributes the attribute properties.
      * @param x the training instances.
      * @param y the response variable.
@@ -388,6 +399,17 @@ public class RandomForest implements Regression<double[]>, Serializable {
     public RandomForest(Attribute[] attributes, double[][] x, double[] y, int ntrees, int maxNodes) {
         this(attributes, x, y, ntrees, maxNodes, 5);
     }
+
+    /**
+     * Constructor. Learns a random forest for regression.
+     *
+     * @param data the dataset
+     * @param ntrees the number of trees.
+     * @param maxNodes the maximum number of leaf nodes in the tree.
+     */
+    public RandomForest(AttributeDataset data, int ntrees, int maxNodes) {
+        this(data.attributes(), data.x(), data.y(), ntrees, maxNodes);
+    }    
 
     /**
      * Constructor. Learns a random forest for regression.
@@ -403,6 +425,19 @@ public class RandomForest implements Regression<double[]>, Serializable {
     public RandomForest(Attribute[] attributes, double[][] x, double[] y, int ntrees, int maxNodes, int nodeSize) {
         this(attributes, x, y, ntrees, maxNodes, nodeSize, x[0].length / 3);
     }
+
+    /**
+     * Constructor. Learns a random forest for regression.
+     *
+     * @param data the dataset
+     * @param ntrees the number of trees.
+     * @param maxNodes the maximum number of leaf nodes in the tree.
+     * @param nodeSize the number of instances in a node below which the tree will
+     * not split, setting nodeSize = 5 generally gives good results.
+     */
+    public RandomForest(AttributeDataset data, int ntrees, int maxNodes, int nodeSize) {
+        this(data.attributes(), data.x(), data.y(), ntrees, maxNodes, nodeSize);
+    }    
 
     /**
      * Constructor. Learns a random forest for regression.
@@ -440,6 +475,24 @@ public class RandomForest implements Regression<double[]>, Serializable {
      */
     public RandomForest(Attribute[] attributes, double[][] x, double[] y, int ntrees, int maxNodes, int nodeSize, int mtry, double subsample) {
         this(attributes, x, y, ntrees, maxNodes, nodeSize, mtry, subsample, null);
+    }
+
+    /**
+     * Constructor. Learns a random forest for regression.
+     *
+     * @param data the dataset
+     * @param ntrees the number of trees.
+     * @param mtry the number of input variables to be used to determine the decision
+     * at a node of the tree. p/3 seems to give generally good performance,
+     * where dim is the number of variables.
+     * @param nodeSize the number of instances in a node below which the tree will
+     * not split, setting nodeSize = 5 generally gives good results.
+     * @param maxNodes the maximum number of leaf nodes in the tree.
+     * @param subsample the sampling rate for training tree. 1.0 means sampling with replacement. < 1.0 means
+     *                  sampling without replacement.
+     */
+    public RandomForest(AttributeDataset data, int ntrees, int maxNodes, int nodeSize, int mtry, double subsample, double[] monotonicRegression) {
+        this(data.attributes(), data.x(), data.y(), ntrees, maxNodes, nodeSize, mtry, subsample, monotonicRegression);
     }
 
     /**

--- a/core/src/main/java/smile/regression/RegressionTree.java
+++ b/core/src/main/java/smile/regression/RegressionTree.java
@@ -17,7 +17,6 @@ package smile.regression;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -26,6 +25,7 @@ import java.util.concurrent.Callable;
 import java.util.stream.IntStream;
 
 import smile.data.Attribute;
+import smile.data.AttributeDataset;
 import smile.data.NominalAttribute;
 import smile.data.NumericAttribute;
 import smile.math.Math;
@@ -931,6 +931,17 @@ public class RegressionTree implements Regression<double[]>, Serializable {
     }
 
     /**
+     * Constructor. Learns a regression tree for random forest and gradient tree boosting.
+     *
+     * @param data       the dataset.
+     * @param maxNodes   the maximum number of leaf nodes in the tree.
+     *                   samples[i] should be 0 or 1 to indicate if the instance is used for training.
+     */
+    public RegressionTree(AttributeDataset data, int maxNodes) {
+        this(data.attributes(), data.x(), data.y(), maxNodes);
+    }    
+
+    /**
      * Constructor. Learns a regression tree with (most) given number of leaves.
      *
      * @param attributes the attribute properties.
@@ -941,6 +952,18 @@ public class RegressionTree implements Regression<double[]>, Serializable {
     public RegressionTree(Attribute[] attributes, double[][] x, double[] y, int maxNodes, int nodeSize) {
         this(attributes, x, y, maxNodes, nodeSize, x[0].length, null, null, null);
     }
+
+    /**
+     * Constructor. Learns a regression tree for random forest and gradient tree boosting.
+     *
+     * @param data       the dataset.
+     * @param maxNodes   the maximum number of leaf nodes in the tree.
+     * @param nodeSize   the number of instances in a node below which the tree will
+     *                   not split, setting nodeSize = 5 generally gives good results.
+     */
+    public RegressionTree(AttributeDataset data, int maxNodes, int nodeSize) {
+        this(data.attributes(), data.x(), data.y(), maxNodes, nodeSize);
+    }    
 
     /**
      * Constructor. Learns a regression tree for random forest and gradient tree boosting.
@@ -961,6 +984,29 @@ public class RegressionTree implements Regression<double[]>, Serializable {
      */
     public RegressionTree(Attribute[] attributes, double[][] x, double[] y, int maxNodes, int nodeSize, int mtry, int[][] order, int[] samples, NodeOutput output) {
         this(attributes, x, y, maxNodes, nodeSize, mtry, order, samples, output, null);
+    }
+
+    /**
+     * Constructor. Learns a regression tree for random forest and gradient tree boosting.
+     *
+     * @param data       the dataset.
+     * @param maxNodes   the maximum number of leaf nodes in the tree.
+     * @param nodeSize   the number of instances in a node below which the tree will
+     *                   not split, setting nodeSize = 5 generally gives good results.
+     * @param mtry       the number of input variables to pick to split on at each
+     *                   node. It seems that p/3 give generally good performance, where p
+     *                   is the number of variables.
+     * @param order      the index of training values in ascending order. Note
+     *                   that only numeric attributes need be sorted.
+     * @param samples    the sample set of instances for stochastic learning.
+     *                   samples[i] should be 0 or 1 to indicate if the instance is used for training.
+     */
+    public RegressionTree(AttributeDataset data, int maxNodes, int nodeSize, int mtry, int[][] order, int[] samples, NodeOutput output) {
+        this(data.attributes(), data.x(), data.y(), maxNodes, nodeSize, mtry, order, samples, output);
+    }
+
+    public RegressionTree(AttributeDataset data, int maxNodes, int nodeSize, int mtry, int[][] order, int[] samples, NodeOutput output, double[] monotonicRegression) {
+        this(data.attributes(), data.x(), data.y(), maxNodes, nodeSize, mtry, order, samples, output, monotonicRegression);
     }
 
     public RegressionTree(Attribute[] attributes, double[][] x, double[] y, int maxNodes, int nodeSize, int mtry, int[][] order, int[] samples, NodeOutput output, double[] monotonicRegression) {


### PR DESCRIPTION
AttributeDataset is often much easier to construct because you can convert arff files, Tablesaw tables, etc. to `AttributeDataset`

We probably don't need constructors taking `Attribute[] attributes, double[][] x, int/double[] y` as it's easier to just pass an `AttributeDataset` but I left them for backwards compatibility