### PR TITLE
Allow for arbitrary column to contain row names/IDs

### DIFF
--- a/data/src/main/java/smile/data/parser/DelimitedTextParser.java
+++ b/data/src/main/java/smile/data/parser/DelimitedTextParser.java
@@ -62,9 +62,9 @@ public class DelimitedTextParser {
      */
     private boolean hasColumnNames = false;
     /**
-     * The dataset has row names at first column.
+     * The dataset has row names at this column.
      */
-    private boolean hasRowNames = false;
+    private int rowNameIndex = -1;
     /**
      * The attribute of dependent/response variable.
      */
@@ -170,17 +170,34 @@ public class DelimitedTextParser {
 
 
     /**
-     * Returns if the dataset has row names (at column 0).
+     * Returns if the dataset contains row names
      */
     public boolean hasRowNames() {
-        return hasRowNames;
+        return rowNameIndex >= 0;
+    }
+
+    /**
+     * Returns the index number for row names of dataset
+     */
+    public int getRowNameIndex() {
+        return rowNameIndex;
     }
 
     /**
      * Set if the dataset has row names (at column 0).
      */
     public DelimitedTextParser setRowNames(boolean hasRowNames) {
-        this.hasRowNames = hasRowNames;
+        if(hasRowNames){
+            setRowNamesIndex(0);
+        }
+        return this;
+    }
+
+    /**
+     * Sets the dataset row names index.
+     */
+    public DelimitedTextParser setRowNamesIndex(int index) {
+        this.rowNameIndex = index;
         return this;
     }
 
@@ -321,8 +338,8 @@ public class DelimitedTextParser {
             throw new IOException("Empty data source.");
         }
 
-        if (hasRowNames) {
-            addIgnoredColumn(0);
+        if (rowNameIndex >= 0) {
+            addIgnoredColumn(rowNameIndex);
         }
 
         String[] s = line.split(delimiter, 0);
@@ -382,7 +399,7 @@ public class DelimitedTextParser {
                 }
             }
         } else {
-            String rowName = hasRowNames ? s[0] : null;
+            String rowName = rowNameIndex >= 0 ? s[rowNameIndex] : null;
             double[] x = new double[attributes.length];
             double y = Double.NaN;
 
@@ -413,7 +430,7 @@ public class DelimitedTextParser {
                 throw new ParseException(String.format("%d columns, expected %d", s.length, ncols), s.length);
             }
 
-            String rowName = hasRowNames ? s[0] : null;
+            String rowName = rowNameIndex >= 0 ? s[rowNameIndex] : null;
             double[] x = new double[attributes.length];
             double y = Double.NaN;
 

--- a/demo/src/main/java/smile/demo/mds/IsotonicMDSDemo.java
+++ b/demo/src/main/java/smile/demo/mds/IsotonicMDSDemo.java
@@ -153,10 +153,10 @@ public class IsotonicMDSDemo extends JPanel implements Runnable, ActionListener 
             if (dataset[datasetIndex] == null) {
                 DelimitedTextParser parser = new DelimitedTextParser();
                 parser.setDelimiter("[\t]+");
-                parser.setRowNames(true);
+                parser.setRowNamesIndex(0);
                 parser.setColumnNames(true);
                 if (datasetIndex == 2 || datasetIndex == 3) {
-                    parser.setRowNames(false);
+                    parser.setRowNamesIndex(-1);
                 }
 
                 try {

--- a/demo/src/main/java/smile/demo/mds/MDSDemo.java
+++ b/demo/src/main/java/smile/demo/mds/MDSDemo.java
@@ -153,10 +153,10 @@ public class MDSDemo extends JPanel implements Runnable, ActionListener {
             if (dataset[datasetIndex] == null) {
                 DelimitedTextParser parser = new DelimitedTextParser();
                 parser.setDelimiter("[\t]+");
-                parser.setRowNames(true);
+                parser.setRowNamesIndex(0);
                 parser.setColumnNames(true);
                 if (datasetIndex == 2 || datasetIndex == 3) {
-                    parser.setRowNames(false);
+                    parser.setRowNamesIndex(-1);
                 }
 
                 try {

--- a/demo/src/main/java/smile/demo/mds/SammonMappingDemo.java
+++ b/demo/src/main/java/smile/demo/mds/SammonMappingDemo.java
@@ -153,10 +153,10 @@ public class SammonMappingDemo extends JPanel implements Runnable, ActionListene
             if (dataset[datasetIndex] == null) {
                 DelimitedTextParser parser = new DelimitedTextParser();
                 parser.setDelimiter("[\t]+");
-                parser.setRowNames(true);
+                parser.setRowNamesIndex(0);
                 parser.setColumnNames(true);
                 if (datasetIndex == 2 || datasetIndex == 3) {
-                    parser.setRowNames(false);
+                    parser.setRowNamesIndex(-1);
                 }
 
                 try {

--- a/demo/src/main/java/smile/demo/projection/ProjectionDemo.java
+++ b/demo/src/main/java/smile/demo/projection/ProjectionDemo.java
@@ -123,7 +123,7 @@ public abstract class ProjectionDemo extends JPanel implements Runnable, ActionL
                     parser.setColumnNames(true);
                 }
                 if (datasetIndex == 1) {
-                    parser.setRowNames(true);
+                    parser.setRowNamesIndex(0);
                 }
                 if (datasetIndex == 0) {
                     parser.setResponseIndex(new NominalAttribute("class"), 4);

--- a/scala/src/main/scala/smile/io/package.scala
+++ b/scala/src/main/scala/smile/io/package.scala
@@ -321,10 +321,10 @@ object read {
     * @param comment the start of comment lines
     * @param missing the missing value placeholder
     * @param header true if the first row is header/column names
-    * @param rowNames true if the first column is row id/names
+    * @param rowNamesIndex the index where the row names will be found if row names are there in dataset else -1
     * @return an attribute dataset
     */
-  def table(file: String, attributes: Array[Attribute] = null, response: Option[(Attribute, Int)] = None, delimiter: String = "\\s+", comment: String = "%", missing: String = "?", header: Boolean = false, rowNames: Boolean = false): AttributeDataset = {
+  def table(file: String, attributes: Array[Attribute] = null, response: Option[(Attribute, Int)] = None, delimiter: String = "\\s+", comment: String = "%", missing: String = "?", header: Boolean = false, rowNamesIndex: Int): AttributeDataset = {
     val parser = new DelimitedTextParser
 
     response match {
@@ -336,13 +336,13 @@ object read {
       .setCommentStartWith(comment)
       .setMissingValuePlaceholder(missing)
       .setColumnNames(header)
-      .setRowNames(rowNames)
+      .setRowNamesIndex(rowNamesIndex)
       .parse(attributes, file)
   }
 
   /** Reads a CSV file  with response variable. */
-  def csv(file: String, attributes: Array[Attribute] = null, response: Option[(Attribute, Int)] = None, comment: String = "%", missing: String = "?", header: Boolean = false, rowNames: Boolean = false): AttributeDataset = {
-    table(file, attributes, response, ",", comment, missing, header, rowNames)
+  def csv(file: String, attributes: Array[Attribute] = null, response: Option[(Attribute, Int)] = None, comment: String = "%", missing: String = "?", header: Boolean = false, rowNamesIndex: Int): AttributeDataset = {
+    table(file, attributes, response, ",", comment, missing, header, rowNamesIndex)
   }
 
   /** Reads GCT microarray gene expression file. */


### PR DESCRIPTION
Using integer instead of boolean value for row names column index
and this integer points to the column index where we'll get the row names
Link to the issue: https://github.com/haifengl/smile/issues/217