### PR TITLE
Bugfix Dataset.iterator()

### DIFF
--- a/data/src/main/java/smile/data/Dataset.java
+++ b/data/src/main/java/smile/data/Dataset.java
@@ -266,28 +266,30 @@ public class Dataset<E> implements Iterable<Datum<E>> {
      */
     @Override
     public Iterator<Datum<E>> iterator() {
-        return new Iterator<Datum<E>>() {
+        return data.iterator();
+        //BUGFIX:  .remove() was broken-- first one worked, but additional ones used the wrong index positions
+//         return new Iterator<Datum<E>>() {
 
-            /**
-             * Current position.
-             */
-            int i = 0;
+//             /**
+//              * Current position.
+//              */
+//             int i = 0;
 
-            @Override
-            public boolean hasNext() {
-                return i < data.size();
-            }
+//             @Override
+//             public boolean hasNext() {
+//                 return i < data.size();
+//             }
 
-            @Override
-            public Datum<E> next() {
-                return get(i++);
-            }
+//             @Override
+//             public Datum<E> next() {
+//                 return get(i++);
+//             }
 
-            @Override
-            public void remove() {
-                Dataset.this.remove(i);
-            }
-        };
+//             @Override
+//             public void remove() {
+//                 Dataset.this.remove(i);
+//             }
+//         };
     }
 
     /** Returns the response values. */


### PR DESCRIPTION
The iterator remove() operation used the index relative to the original dataset, but if you've already removed some items, then it removes the wrong positions.