### PR TITLE
add ReducedErrorPruning for decision/regression tree

### DIFF
--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -461,7 +461,7 @@ public class DecisionTree implements SoftClassifier<double[]> {
 			// start post pruning
 			Node candidate = candidates.size() == 0 ? null : candidates.remove(candidates.size() - 1);
 			while (candidate != null) {
-				boolean prune = pruneSubTree(candidate, candidates, flags);
+				boolean prune = pruneSubTree(dt, candidate, candidates, flags);
 				if (prune) {
 					candidates.sort(c);
 				}
@@ -497,7 +497,7 @@ public class DecisionTree implements SoftClassifier<double[]> {
 			return new int[] { error, total };
 		}
 
-		private static boolean pruneSubTree(Node n, List<Node> candidates, Set<Integer> flags) {
+		private static boolean pruneSubTree(DecisionTree dt, Node n, List<Node> candidates, Set<Integer> flags) {
 			boolean ret = false;
 
 			Map<Integer, Integer> respCount = new HashMap<Integer, Integer>();
@@ -546,6 +546,8 @@ public class DecisionTree implements SoftClassifier<double[]> {
 			ret = errRateAfter < errRateBefore;
 			// prune the subtree and from bottom-up
 			if (ret) {
+				dt.importance[n.splitFeature] -= n.splitScore;
+				
 				n.response.addAll(n.trueChild.response);
 				n.response.addAll(n.falseChild.response);
 				n.prediction = new ArrayList<Integer>(total);

--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -270,19 +270,19 @@ public class DecisionTree implements SoftClassifier<double[]> {
         CLASSIFICATION_ERROR
     }
 	
-	/**
-	 * node number.
-	 */
-	private static AtomicInteger nodeNumber = new AtomicInteger(0);
+    /**
+     * node number.
+     */
+    private static AtomicInteger nodeNumber = new AtomicInteger(0);
 
 	/**
 	 * Classification tree node.
 	 */
 	class Node implements Serializable {
-		/**
-		 * node index.
-		 */
-		int index = -1;
+        /**
+         * node index.
+         */
+        int index = -1;
         /**
          * Predicted class label for this node.
          */
@@ -304,10 +304,10 @@ public class DecisionTree implements SoftClassifier<double[]> {
          * Reduction in splitting criterion.
          */
         double splitScore = 0.0;
-		/**
-		 * Parent node.
-		 */
-		Node parent = null;
+        /**
+         * Parent node.
+         */
+        Node parent = null;
         /**
          * Children node.
          */
@@ -316,7 +316,7 @@ public class DecisionTree implements SoftClassifier<double[]> {
          * Children node.
          */
         Node falseChild = null;
-
+        
         /**
          * Predicted output for children node.
          */
@@ -414,160 +414,160 @@ public class DecisionTree implements SoftClassifier<double[]> {
         }
     }
     
-	/**
-	 * Starting at the leaves, each node is replaced with its most popular class. If
-	 * the prediction accuracy is not affected then the change is kept. While
-	 * somewhat naive, reduced error pruning has the advantage of simplicity and
-	 * speed.
-	 * 
-	 * @author rayeaster
-	 *
-	 */
-	public static class ReducedErrorPostPruning {
+    /**
+     * Starting at the leaves, each node is replaced with its most popular class. If
+     * the prediction accuracy is not affected then the change is kept. While
+     * somewhat naive, reduced error pruning has the advantage of simplicity and
+     * speed.
+     * 
+     * @author rayeaster
+     *
+     */
+    public static class ReducedErrorPostPruning {
 
-		/**
-		 * post pruning using validation dataset
-		 * 
-		 * @param dt
-		 *            fully-grown Decision Tree
-		 * @param validatex
-		 *            validation dataset
-		 * @param validatey
-		 *            validation dataset repsonse
-		 */
-		public static void postPruning(DecisionTree dt, double[][] validatex, int[] validatey) {
-			Node root = dt.root;
+        /**
+         * post pruning using validation dataset
+         * 
+         * @param dt
+         *            fully-grown Decision Tree
+         * @param validatex
+         *            validation dataset
+         * @param validatey
+         *            validation dataset repsonse
+         */
+        public static void postPruning(DecisionTree dt, double[][] validatex, int[] validatey) {
+            Node root = dt.root;
 
-			List<Node> candidates = new LinkedList<Node>();
-			Set<Integer> flags = new HashSet<Integer>();
+            List<Node> candidates = new LinkedList<Node>();
+            Set<Integer> flags = new HashSet<Integer>();
 
-			// update node for validate data
-			for (int i = 0; i < validatey.length; i++) {
-				double[] data = validatex[i];
-				predict(root, data, validatey[i], candidates, flags);
-			}
+            // update node for validate data
+            for (int i = 0; i < validatey.length; i++) {
+                double[] data = validatex[i];
+                predict(root, data, validatey[i], candidates, flags);
+            }
 
-			// from bottom-up
-			Comparator c = new Comparator<Node>() {
+            // from bottom-up
+            Comparator c = new Comparator<Node>() {
 
-				@Override
-				public int compare(Node o1, Node o2) {
-					return o1.index - o2.index;
-				}
+                @Override
+                public int compare(Node o1, Node o2) {
+                    return o1.index - o2.index;
+                }
 
-			};
-			candidates.sort(c);
+            };
+            candidates.sort(c);
 
-			// start post pruning
-			Node candidate = candidates.size() == 0 ? null : candidates.remove(candidates.size() - 1);
-			while (candidate != null) {
-				boolean prune = pruneSubTree(dt, candidate, candidates, flags);
-				if (prune) {
-					candidates.sort(c);
-				}
-				candidate = candidates.size() == 0 ? null : candidates.remove(candidates.size() - 1);
-			}
-		}
+            // start post pruning
+            Node candidate = candidates.size() == 0 ? null : candidates.remove(candidates.size() - 1);
+            while (candidate != null) {
+                boolean prune = pruneSubTree(dt, candidate, candidates, flags);
+                if (prune) {
+                    candidates.sort(c);
+                }
+                candidate = candidates.size() == 0 ? null : candidates.remove(candidates.size() - 1);
+            }
+        }
 
-		private static Node predict(Node n, double[] x, int y, List<Node> candidates, Set<Integer> flags) {
-			Node ret = n.predict(x);
-			int prediction = ret.output;
-			if (ret.trueChild == null && ret.falseChild == null) {
-				ret.response.add(y);
-				ret.prediction.add(prediction);
-				if (ret.parent != null && flags.contains(ret.parent.index) == false) {
-					candidates.add(ret.parent);
-					flags.add(ret.parent.index);
-				}
-			}
-			return ret;
-		}
+        private static Node predict(Node n, double[] x, int y, List<Node> candidates, Set<Integer> flags) {
+            Node ret = n.predict(x);
+            int prediction = ret.output;
+            if (ret.trueChild == null && ret.falseChild == null) {
+                ret.response.add(y);
+                ret.prediction.add(prediction);
+                if (ret.parent != null && flags.contains(ret.parent.index) == false) {
+                    candidates.add(ret.parent);
+                    flags.add(ret.parent.index);
+                }
+            }
+            return ret;
+        }
 
-		private static int[] getErrorAndTotal(Node n) {
-			int error = 0;
-			int total = 0;
-			if (n.trueChild == null && n.falseChild == null) {
-				for (int i = 0; i < n.response.size(); i++) {
-					int response = n.response.get(i);
-					int prediction = n.prediction.get(i);
-					error += (response == prediction ? 0 : 1);
-					total++;
-				}
-			}
-			return new int[] { error, total };
-		}
+        private static int[] getErrorAndTotal(Node n) {
+            int error = 0;
+            int total = 0;
+            if (n.trueChild == null && n.falseChild == null) {
+                for (int i = 0; i < n.response.size(); i++) {
+                    int response = n.response.get(i);
+                    int prediction = n.prediction.get(i);
+                    error += (response == prediction ? 0 : 1);
+                    total++;
+                }
+            }
+            return new int[] { error, total };
+        }
 
-		private static boolean pruneSubTree(DecisionTree dt, Node n, List<Node> candidates, Set<Integer> flags) {
-			boolean ret = false;
+        private static boolean pruneSubTree(DecisionTree dt, Node n, List<Node> candidates, Set<Integer> flags) {
+            boolean ret = false;
 
-			Map<Integer, Integer> respCount = new HashMap<Integer, Integer>();
-			for (Integer resp : n.trueChild.response) {
-				Integer cnt = respCount.get(resp);
-				if (cnt == null) {
-					respCount.put(resp, 1);
-				} else {
-					respCount.put(resp, cnt + 1);
-				}
-			}
-			for (Integer resp : n.falseChild.response) {
-				Integer cnt = respCount.get(resp);
-				if (cnt == null) {
-					respCount.put(resp, 1);
-				} else {
-					respCount.put(resp, cnt + 1);
-				}
-			}
-			int outputResp = n.output;
-			int maxRespCount = Integer.MIN_VALUE;
-			for (Entry<Integer, Integer> ent : respCount.entrySet()) {
-				if (ent.getValue() > maxRespCount) {
-					maxRespCount = ent.getValue();
-					outputResp = ent.getKey();
-				}
-			}
-			// get error rate before prune
-			int[] trueErrorAndTotal = getErrorAndTotal(n.trueChild);
-			int[] falseErrorAndTotal = getErrorAndTotal(n.falseChild);
-			int total = trueErrorAndTotal[1] + falseErrorAndTotal[1];
-			double errRateBefore = (double) (trueErrorAndTotal[0] + falseErrorAndTotal[0]) / (double) (total);
-			// get error rate after prune
-			int errorAfter = 0;
-			for (Integer resp : n.trueChild.response) {
-				if (!resp.equals(outputResp)) {
-					errorAfter++;
-				}
-			}
-			for (Integer resp : n.falseChild.response) {
-				if (!resp.equals(outputResp)) {
-					errorAfter++;
-				}
-			}
-			double errRateAfter = (double) (errorAfter) / (double) (total);
-			ret = errRateAfter < errRateBefore;
-			// prune the subtree and from bottom-up
-			if (ret) {
-				dt.importance[n.splitFeature] -= n.splitScore;
-				
-				n.response.addAll(n.trueChild.response);
-				n.response.addAll(n.falseChild.response);
-				n.prediction = new ArrayList<Integer>(total);
-				for (int i = 0; i < total; i++) {
-					n.prediction.add(outputResp);
-				}
-				n.trueChild = null;
-				n.falseChild = null;
-				n.trueChildOutput = -1;
-				n.falseChildOutput = -1;
-				n.output = outputResp;
-				if (n.parent != null && flags.contains(n.parent.index) == false) {
-					candidates.add(n.parent);
-					flags.add(n.parent.index);
-				}
-				System.out.println("pruning node #" + n.index);
-			}
-			return ret;
-		}
-	}
+            Map<Integer, Integer> respCount = new HashMap<Integer, Integer>();
+            for (Integer resp : n.trueChild.response) {
+                Integer cnt = respCount.get(resp);
+                if (cnt == null) {
+                    respCount.put(resp, 1);
+                } else {
+                    respCount.put(resp, cnt + 1);
+                }
+            }
+            for (Integer resp : n.falseChild.response) {
+                Integer cnt = respCount.get(resp);
+                if (cnt == null) {
+                    respCount.put(resp, 1);
+                } else {
+                    respCount.put(resp, cnt + 1);
+                }
+            }
+            int outputResp = n.output;
+            int maxRespCount = Integer.MIN_VALUE;
+            for (Entry<Integer, Integer> ent : respCount.entrySet()) {
+                if (ent.getValue() > maxRespCount) {
+                    maxRespCount = ent.getValue();
+                    outputResp = ent.getKey();
+                }
+            }
+            // get error rate before prune
+            int[] trueErrorAndTotal = getErrorAndTotal(n.trueChild);
+            int[] falseErrorAndTotal = getErrorAndTotal(n.falseChild);
+            int total = trueErrorAndTotal[1] + falseErrorAndTotal[1];
+            double errRateBefore = (double) (trueErrorAndTotal[0] + falseErrorAndTotal[0]) / (double) (total);
+            // get error rate after prune
+            int errorAfter = 0;
+            for (Integer resp : n.trueChild.response) {
+                if (!resp.equals(outputResp)) {
+                    errorAfter++;
+                }
+            }
+            for (Integer resp : n.falseChild.response) {
+                if (!resp.equals(outputResp)) {
+                    errorAfter++;
+                }
+            }
+            double errRateAfter = (double) (errorAfter) / (double) (total);
+            ret = errRateAfter < errRateBefore;
+            // prune the subtree and from bottom-up
+            if (ret) {
+                dt.importance[n.splitFeature] -= n.splitScore;
+
+                n.response.addAll(n.trueChild.response);
+                n.response.addAll(n.falseChild.response);
+                n.prediction = new ArrayList<Integer>(total);
+                for (int i = 0; i < total; i++) {
+                    n.prediction.add(outputResp);
+                }
+                n.trueChild = null;
+                n.falseChild = null;
+                n.trueChildOutput = -1;
+                n.falseChildOutput = -1;
+                n.output = outputResp;
+                if (n.parent != null && flags.contains(n.parent.index) == false) {
+                    candidates.add(n.parent);
+                    flags.add(n.parent.index);
+                }
+                System.out.println("pruning node #" + n.index);
+            }
+            return ret;
+        }
+    }
 
     /**
      * Classification tree node for training purpose.

--- a/core/src/main/java/smile/regression/RegressionTree.java
+++ b/core/src/main/java/smile/regression/RegressionTree.java
@@ -417,7 +417,7 @@ public class RegressionTree implements Regression<double[]> {
 			// start post pruning
 			Node candidate = candidates.size() == 0 ? null : candidates.remove(candidates.size() - 1);
 			while (candidate != null) {
-				boolean prune = pruneSubTree(candidate, candidates, flags);
+				boolean prune = pruneSubTree(dt, candidate, candidates, flags);
 				if (prune) {
 					candidates.sort(c);
 				}
@@ -453,7 +453,7 @@ public class RegressionTree implements Regression<double[]> {
 			return new double[] {error, total};
 		}
 
-		private static boolean pruneSubTree(Node n, List<Node> candidates, Set<Integer> flags) {
+		private static boolean pruneSubTree(RegressionTree dt, Node n, List<Node> candidates, Set<Integer> flags) {
 			boolean ret = false;			
 			double outputResp = (n.trueChildOutput + n.falseChildOutput) / 2;
 			
@@ -474,6 +474,8 @@ public class RegressionTree implements Regression<double[]> {
 			ret = errRateAfter < errRateBefore;
 			// prune the subtree and from bottom-up
 			if (ret) {
+				dt.importance[n.splitFeature] -= n.splitScore;
+				
 				n.response.addAll(n.trueChild.response);
 				n.response.addAll(n.falseChild.response);
 				n.prediction = new ArrayList<Double>(total);

--- a/core/src/main/java/smile/regression/RegressionTree.java
+++ b/core/src/main/java/smile/regression/RegressionTree.java
@@ -262,19 +262,19 @@ public class RegressionTree implements Regression<double[]> {
         public double calculate(int[] samples);
     }
 	
-	/**
-	 * node number.
-	 */
-	private static AtomicInteger nodeNumber = new AtomicInteger(0);
+    /**
+     * node number.
+     */
+    private static AtomicInteger nodeNumber = new AtomicInteger(0);
 
-	/**
-	 * Regression tree node.
-	 */
-	class Node implements Serializable {
-		/**
-		 * node index.
-		 */
-		int index = -1;
+    /**
+     * Regression tree node.
+     */
+    class Node implements Serializable {
+        /**
+         * node index.
+         */
+        int index = -1;
         /**
          * Predicted real value for this node.
          */
@@ -314,21 +314,21 @@ public class RegressionTree implements Regression<double[]> {
          * Predicted output for children node.
          */
         double falseChildOutput = 0.0;
-		/**
-		 * response of validation data in this node if leaf, used for post pruning
-		 */
-		List<Double> response = new ArrayList<Double>();
-		/**
-		 * prediction of validation data in this node if leaf, used for post pruning
-		 */
-		List<Double> prediction = new ArrayList<Double>();
+        /**
+         * response of validation data in this node if leaf, used for post pruning
+         */
+        List<Double> response = new ArrayList<Double>();
+        /**
+         * prediction of validation data in this node if leaf, used for post pruning
+         */
+        List<Double> prediction = new ArrayList<Double>();
 
         /**
          * Constructor.
          */
         public Node(double output) {
             this.output = output;
-			this.index = nodeNumber.incrementAndGet();
+            this.index = nodeNumber.incrementAndGet();
         }
 
         /**
@@ -370,132 +370,132 @@ public class RegressionTree implements Regression<double[]> {
         }
     }
 	
-	/**
-	 * Starting at the leaves, each node is replaced with its most popular class. If
-	 * the prediction accuracy is not affected then the change is kept. While
-	 * somewhat naive, reduced error pruning has the advantage of simplicity and
-	 * speed.
-	 * 
-	 * @author rayeaster
-	 *
-	 */
-	public static class ReducedErrorPostPruning {
+    /**
+     * Starting at the leaves, each node is replaced with its most popular class. If
+     * the prediction accuracy is not affected then the change is kept. While
+     * somewhat naive, reduced error pruning has the advantage of simplicity and
+     * speed.
+     * 
+     * @author rayeaster
+     *
+     */
+    public static class ReducedErrorPostPruning {
 
-		/**
-		 * post pruning using validation dataset
-		 * 
-		 * @param dt
-		 *            fully-grown Regression Tree
-		 * @param validatex
-		 *            validation dataset
-		 * @param validatey
-		 *            validation dataset repsonse
-		 */
-		public static void postPruning(RegressionTree dt, double[][] validatex, double[] validatey) {
-			Node root = dt.root;
+        /**
+         * post pruning using validation dataset
+         * 
+         * @param dt
+         *            fully-grown Regression Tree
+         * @param validatex
+         *            validation dataset
+         * @param validatey
+         *            validation dataset repsonse
+         */
+        public static void postPruning(RegressionTree dt, double[][] validatex, double[] validatey) {
+            Node root = dt.root;
 
-			List<Node> candidates = new LinkedList<Node>();
-			Set<Integer> flags = new HashSet<Integer>();
+            List<Node> candidates = new LinkedList<Node>();
+            Set<Integer> flags = new HashSet<Integer>();
 
-			// update node for validate data
-			for (int i = 0; i < validatey.length; i++) {
-				double[] data = validatex[i];
-				predict(root, data, validatey[i], candidates, flags);
-			}
+            // update node for validate data
+            for (int i = 0; i < validatey.length; i++) {
+                double[] data = validatex[i];
+                predict(root, data, validatey[i], candidates, flags);
+            }
 
-			// from bottom-up
-			Comparator c = new Comparator<Node>() {
+            // from bottom-up
+            Comparator c = new Comparator<Node>() {
 
-				@Override
-				public int compare(Node o1, Node o2) {
-					return o1.index - o2.index;
-				}
+                @Override
+                public int compare(Node o1, Node o2) {
+                    return o1.index - o2.index;
+                }
 
-			};
-			candidates.sort(c);
+            };
+            candidates.sort(c);
 
-			// start post pruning
-			Node candidate = candidates.size() == 0 ? null : candidates.remove(candidates.size() - 1);
-			while (candidate != null) {
-				boolean prune = pruneSubTree(dt, candidate, candidates, flags);
-				if (prune) {
-					candidates.sort(c);
-				}
-				candidate = candidates.size() == 0 ? null : candidates.remove(candidates.size() - 1);
-			}
-		}
+            // start post pruning
+            Node candidate = candidates.size() == 0 ? null : candidates.remove(candidates.size() - 1);
+            while (candidate != null) {
+                boolean prune = pruneSubTree(dt, candidate, candidates, flags);
+                if (prune) {
+                    candidates.sort(c);
+                }
+                candidate = candidates.size() == 0 ? null : candidates.remove(candidates.size() - 1);
+            }
+        }
 
-		private static Node predict(Node n, double[] x, double y, List<Node> candidates, Set<Integer> flags) {
-			Node ret = n.predict(x);
-			double prediction = ret.output;
-			if (ret.trueChild == null && ret.falseChild == null) {
-				ret.response.add(y);
-				ret.prediction.add(prediction);
-				if (ret.parent != null && flags.contains(ret.parent.index) == false) {
-					candidates.add(ret.parent);
-					flags.add(ret.parent.index);
-				}
-			}
-			return ret;
-		}
+        private static Node predict(Node n, double[] x, double y, List<Node> candidates, Set<Integer> flags) {
+            Node ret = n.predict(x);
+            double prediction = ret.output;
+            if (ret.trueChild == null && ret.falseChild == null) {
+                ret.response.add(y);
+                ret.prediction.add(prediction);
+                if (ret.parent != null && flags.contains(ret.parent.index) == false) {
+                    candidates.add(ret.parent);
+                    flags.add(ret.parent.index);
+                }
+            }
+            return ret;
+        }
 
-		private static double[] getErrorAndTotal(Node n) {
-			double error = 0;
-			double total = 0;
-			if (n.trueChild == null && n.falseChild == null) {
-				for (int i = 0; i < n.response.size(); i++) {
-					double response = n.response.get(i);
-					double prediction = n.prediction.get(i);
-					error += Math.sqr(prediction - response);
-					total++;
-				}
-			}
-			return new double[] {error, total};
-		}
+        private static double[] getErrorAndTotal(Node n) {
+            double error = 0;
+            double total = 0;
+            if (n.trueChild == null && n.falseChild == null) {
+                for (int i = 0; i < n.response.size(); i++) {
+                    double response = n.response.get(i);
+                    double prediction = n.prediction.get(i);
+                    error += Math.sqr(prediction - response);
+                    total++;
+                }
+            }
+            return new double[] { error, total };
+        }
 
-		private static boolean pruneSubTree(RegressionTree dt, Node n, List<Node> candidates, Set<Integer> flags) {
-			boolean ret = false;			
-			double outputResp = (n.trueChildOutput + n.falseChildOutput) / 2;
-			
-			// get error rate before prune
-			double[] trueErrorAndTotal = getErrorAndTotal(n.trueChild);
-			double[] falseErrorAndTotal = getErrorAndTotal(n.falseChild);
-			int total = (int) (trueErrorAndTotal[1] + falseErrorAndTotal[1]);
-			double errRateBefore = (double) (trueErrorAndTotal[0] + falseErrorAndTotal[0]) / (double) (total);
-			// get error rate after prune
-			double errorAfter = 0;
-			for (Double resp : n.trueChild.response) {
-				errorAfter += Math.sqr(outputResp - resp);
-			}
-			for (Double resp : n.falseChild.response) {
-				errorAfter += Math.sqr(outputResp - resp);
-			}
-			double errRateAfter = (double) (errorAfter) / (double) (total);
-			ret = errRateAfter < errRateBefore;
-			// prune the subtree and from bottom-up
-			if (ret) {
-				dt.importance[n.splitFeature] -= n.splitScore;
-				
-				n.response.addAll(n.trueChild.response);
-				n.response.addAll(n.falseChild.response);
-				n.prediction = new ArrayList<Double>(total);
-				for (int i = 0; i < total; i++) {
-					n.prediction.add(outputResp);
-				}
-				n.trueChild = null;
-				n.falseChild = null;
-				n.trueChildOutput = -1;
-				n.falseChildOutput = -1;
-				n.output = outputResp;
-				if (n.parent != null && flags.contains(n.parent.index) == false) {
-					candidates.add(n.parent);
-					flags.add(n.parent.index);
-				}
-				System.out.println("pruning node #" + n.index);
-			}
-			return ret;
-		}
-	}
+        private static boolean pruneSubTree(RegressionTree dt, Node n, List<Node> candidates, Set<Integer> flags) {
+            boolean ret = false;
+            double outputResp = (n.trueChildOutput + n.falseChildOutput) / 2;
+
+            // get error rate before prune
+            double[] trueErrorAndTotal = getErrorAndTotal(n.trueChild);
+            double[] falseErrorAndTotal = getErrorAndTotal(n.falseChild);
+            int total = (int) (trueErrorAndTotal[1] + falseErrorAndTotal[1]);
+            double errRateBefore = (double) (trueErrorAndTotal[0] + falseErrorAndTotal[0]) / (double) (total);
+            // get error rate after prune
+            double errorAfter = 0;
+            for (Double resp : n.trueChild.response) {
+                errorAfter += Math.sqr(outputResp - resp);
+            }
+            for (Double resp : n.falseChild.response) {
+                errorAfter += Math.sqr(outputResp - resp);
+            }
+            double errRateAfter = (double) (errorAfter) / (double) (total);
+            ret = errRateAfter < errRateBefore;
+            // prune the subtree and from bottom-up
+            if (ret) {
+                dt.importance[n.splitFeature] -= n.splitScore;
+
+                n.response.addAll(n.trueChild.response);
+                n.response.addAll(n.falseChild.response);
+                n.prediction = new ArrayList<Double>(total);
+                for (int i = 0; i < total; i++) {
+                    n.prediction.add(outputResp);
+                }
+                n.trueChild = null;
+                n.falseChild = null;
+                n.trueChildOutput = -1;
+                n.falseChildOutput = -1;
+                n.output = outputResp;
+                if (n.parent != null && flags.contains(n.parent.index) == false) {
+                    candidates.add(n.parent);
+                    flags.add(n.parent.index);
+                }
+                System.out.println("pruning node #" + n.index);
+            }
+            return ret;
+        }
+    }
 
     /**
      * Regression tree node for training purpose.

--- a/core/src/test/java/smile/classification/DecisionTreeTest.java
+++ b/core/src/test/java/smile/classification/DecisionTreeTest.java
@@ -130,10 +130,10 @@ public class DecisionTreeTest {
         try {
             AttributeDataset train = parser.parse("USPS Train", smile.data.parser.IOUtils.getTestDataFile("usps/zip.train"));
             AttributeDataset test = parser.parse("USPS Test", smile.data.parser.IOUtils.getTestDataFile("usps/zip.test"));
-            
+
             int splitIdx = train.size() / 2;
             double[][] x = train.range(0, splitIdx).toArray(new double[splitIdx][]);
-            int[] y  = train.range(0, splitIdx).toArray(new int[splitIdx]);
+            int[] y = train.range(0, splitIdx).toArray(new int[splitIdx]);
             double[][] testx = test.toArray(new double[test.size()][]);
             int[] testy = test.toArray(new int[test.size()]);
             
@@ -149,11 +149,11 @@ public class DecisionTreeTest {
             double er1 = 100.0 * error / testx.length;
             System.out.format("USPS error rate = %.2f%%%n", er1);
             assertEquals(406, error);
-            
+
             double[][] validx = train.range(splitIdx, train.size()).toArray(new double[train.size() - splitIdx][]);
-            int[] validy  = train.range(splitIdx, train.size()).toArray(new int[train.size() - splitIdx]);
+            int[] validy = train.range(splitIdx, train.size()).toArray(new int[train.size() - splitIdx]);
             DecisionTree.ReducedErrorPostPruning.postPruning(tree, validx, validy);
-            
+
             error = 0;
             for (int i = 0; i < testx.length; i++) {
                 if (tree.predict(testx[i]) != testy[i]) {

--- a/core/src/test/java/smile/regression/RegressionTreeTest.java
+++ b/core/src/test/java/smile/regression/RegressionTreeTest.java
@@ -29,6 +29,7 @@ import smile.validation.LOOCV;
 import smile.validation.Validation;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -193,6 +194,56 @@ public class RegressionTreeTest {
             for (int i = importance.length; i-- > 0; ) {
                 System.out.format("%s importance is %.4f%n", data.attributes()[index[i]], importance[i]);
             }
+        } catch (Exception ex) {
+            System.err.println(ex);
+        }
+    }
+    
+    /**
+     * Test of post pruning method, of class RegressionTree.
+     */
+    @Test
+    public void testWithPostPruning() {
+        System.out.println("---Post Pruning---");
+        ArffParser parser = new ArffParser();
+        parser.setResponseIndex(8);
+        try {
+            AttributeDataset data = parser.parse(smile.data.parser.IOUtils.getTestDataFile("weka/regression/puma8NH.arff"));
+
+            int splitTrain = 4 * data.size() / 5;
+            int splitIdx = 2 * data.size() / 5;
+            double[][] trainx = data.range(0, splitIdx).toArray(new double[splitIdx][]);
+            double[] trainy  = data.range(0, splitIdx).toArray(new double[splitIdx]);
+
+            double[][] validatex = data.range(splitIdx, splitTrain).toArray(new double[splitTrain - splitIdx][]);
+            double[] validatey  = data.range(splitIdx, splitTrain).toArray(new double[splitTrain - splitIdx]);            
+
+            double[][] testx = data.range(splitTrain, data.size()).toArray(new double[data.size() - splitTrain][]);
+            double[] testy  = data.range(splitIdx, data.size()).toArray(new double[data.size() - splitTrain]);
+
+            RegressionTree tree = new RegressionTree(data.attributes(), trainx, trainy, 20);
+            double mse1 = 0;
+            for (int j = 0; j < testx.length; j++) {
+                double r = testy[j] - tree.predict(testx[j]);
+                mse1 += r * r;
+            }
+            System.out.format("Puma RMSE = %.4f%n", Math.sqrt(mse1/testy.length));
+            
+            double[] importance = tree.importance();
+            int[] index = QuickSort.sort(importance);
+            for (int i = importance.length; i-- > 0; ) {
+                System.out.format("%s importance is %.4f%n", data.attributes()[index[i]], importance[i]);
+            }
+            
+            RegressionTree.ReducedErrorPostPruning.postPruning(tree, validatex, validatey);
+            double mse2 = 0;
+            for (int j = 0; j < testx.length; j++) {
+                double r = testy[j] - tree.predict(testx[j]);
+                mse2 += r * r;
+            }
+            System.out.format("After pruning Puma RMSE = %.4f%n", Math.sqrt(mse2/testy.length));
+            assertTrue(mse2 < mse1);
+            
         } catch (Exception ex) {
             System.err.println(ex);
         }

--- a/core/src/test/java/smile/regression/RegressionTreeTest.java
+++ b/core/src/test/java/smile/regression/RegressionTreeTest.java
@@ -208,18 +208,19 @@ public class RegressionTreeTest {
         ArffParser parser = new ArffParser();
         parser.setResponseIndex(8);
         try {
-            AttributeDataset data = parser.parse(smile.data.parser.IOUtils.getTestDataFile("weka/regression/puma8NH.arff"));
+            AttributeDataset data = parser
+                    .parse(smile.data.parser.IOUtils.getTestDataFile("weka/regression/puma8NH.arff"));
 
             int splitTrain = 4 * data.size() / 5;
             int splitIdx = 2 * data.size() / 5;
             double[][] trainx = data.range(0, splitIdx).toArray(new double[splitIdx][]);
-            double[] trainy  = data.range(0, splitIdx).toArray(new double[splitIdx]);
+            double[] trainy = data.range(0, splitIdx).toArray(new double[splitIdx]);
 
             double[][] validatex = data.range(splitIdx, splitTrain).toArray(new double[splitTrain - splitIdx][]);
-            double[] validatey  = data.range(splitIdx, splitTrain).toArray(new double[splitTrain - splitIdx]);            
+            double[] validatey = data.range(splitIdx, splitTrain).toArray(new double[splitTrain - splitIdx]);
 
             double[][] testx = data.range(splitTrain, data.size()).toArray(new double[data.size() - splitTrain][]);
-            double[] testy  = data.range(splitIdx, data.size()).toArray(new double[data.size() - splitTrain]);
+            double[] testy = data.range(splitIdx, data.size()).toArray(new double[data.size() - splitTrain]);
 
             RegressionTree tree = new RegressionTree(data.attributes(), trainx, trainy, 20);
             double mse1 = 0;
@@ -227,23 +228,23 @@ public class RegressionTreeTest {
                 double r = testy[j] - tree.predict(testx[j]);
                 mse1 += r * r;
             }
-            System.out.format("Puma RMSE = %.4f%n", Math.sqrt(mse1/testy.length));
-            
+            System.out.format("Puma RMSE = %.4f%n", Math.sqrt(mse1 / testy.length));
+
             double[] importance = tree.importance();
             int[] index = QuickSort.sort(importance);
-            for (int i = importance.length; i-- > 0; ) {
+            for (int i = importance.length; i-- > 0;) {
                 System.out.format("%s importance is %.4f%n", data.attributes()[index[i]], importance[i]);
             }
-            
+
             RegressionTree.ReducedErrorPostPruning.postPruning(tree, validatex, validatey);
             double mse2 = 0;
             for (int j = 0; j < testx.length; j++) {
                 double r = testy[j] - tree.predict(testx[j]);
                 mse2 += r * r;
             }
-            System.out.format("After pruning Puma RMSE = %.4f%n", Math.sqrt(mse2/testy.length));
+            System.out.format("After pruning Puma RMSE = %.4f%n", Math.sqrt(mse2 / testy.length));
             assertTrue(mse2 < mse1);
-            
+
         } catch (Exception ex) {
             System.err.println(ex);
         }


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Pruning_(decision_trees)

- add increasing index to each node to distinguish each other;
- add pointer to node's parent;
- add arrays to record response and prediction respectively when passing validation dataset through trained tree for later use in pruning
- test result shows the model has better accuracy for testing data after pruning:

```
classification:
USPS error rate = 20.23%
pruning node #69396
......
After pruning, USPS error rate = 17.99%


regression:
Puma RMSE = 4.0809
pruning node #280
......
After pruning Puma RMSE = 4.0411
```