### PR TITLE
Update missing class text exception in classification models.

### DIFF
--- a/core/src/main/java/smile/classification/AdaBoost.java
+++ b/core/src/main/java/smile/classification/AdaBoost.java
@@ -259,7 +259,7 @@ public class AdaBoost implements SoftClassifier<double[]>, Serializable {
             }
             
             if (i > 0 && labels[i] - labels[i-1] > 1) {
-                throw new IllegalArgumentException("Missing class: " + labels[i]+1);                 
+                throw new IllegalArgumentException("Missing class: " + (labels[i-1]+1));
             }
         }
         

--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -901,7 +901,7 @@ public class DecisionTree implements SoftClassifier<double[]>, Serializable {
             }
             
             if (i > 0 && labels[i] - labels[i-1] > 1) {
-                throw new IllegalArgumentException("Missing class: " + labels[i]+1);                 
+                throw new IllegalArgumentException("Missing class: " + (labels[i-1]+1));
             }
         }
 

--- a/core/src/main/java/smile/classification/FLD.java
+++ b/core/src/main/java/smile/classification/FLD.java
@@ -193,7 +193,7 @@ public class FLD implements Classifier<double[]>, Projection<double[]>, Serializ
             }
             
             if (i > 0 && labels[i] - labels[i-1] > 1) {
-                throw new IllegalArgumentException("Missing class: " + labels[i]+1);                 
+                throw new IllegalArgumentException("Missing class: " + (labels[i-1]+1));
             }
         }
 

--- a/core/src/main/java/smile/classification/KNN.java
+++ b/core/src/main/java/smile/classification/KNN.java
@@ -143,7 +143,7 @@ public class KNN<T> implements SoftClassifier<T>, Serializable {
             }
             
             if (i > 0 && labels[i] - labels[i-1] > 1) {
-                throw new IllegalArgumentException("Missing class: " + labels[i]+1);                 
+                throw new IllegalArgumentException("Missing class: " + (labels[i-1]+1));
             }
         }
 

--- a/core/src/main/java/smile/classification/LDA.java
+++ b/core/src/main/java/smile/classification/LDA.java
@@ -213,7 +213,7 @@ public class LDA implements SoftClassifier<double[]>, Serializable {
             }
             
             if (i > 0 && labels[i] - labels[i-1] > 1) {
-                throw new IllegalArgumentException("Missing class: " + labels[i]+1);                 
+                throw new IllegalArgumentException("Missing class: " + (labels[i-1]+1));
             }
         }
 

--- a/core/src/main/java/smile/classification/LogisticRegression.java
+++ b/core/src/main/java/smile/classification/LogisticRegression.java
@@ -285,7 +285,7 @@ public class LogisticRegression implements SoftClassifier<double[]>, OnlineClass
             }
             
             if (i > 0 && labels[i] - labels[i-1] > 1) {
-                throw new IllegalArgumentException("Missing class: " + labels[i]+1);                 
+                throw new IllegalArgumentException("Missing class: " + (labels[i-1]+1));
             }
         }
 

--- a/core/src/main/java/smile/classification/Maxent.java
+++ b/core/src/main/java/smile/classification/Maxent.java
@@ -227,7 +227,7 @@ public class Maxent implements SoftClassifier<int[]>, Serializable {
             }
             
             if (i > 0 && labels[i] - labels[i-1] > 1) {
-                throw new IllegalArgumentException("Missing class: " + labels[i]+1);                 
+                throw new IllegalArgumentException("Missing class: " + (labels[i-1]+1));
             }
         }
 

--- a/core/src/main/java/smile/classification/QDA.java
+++ b/core/src/main/java/smile/classification/QDA.java
@@ -203,7 +203,7 @@ public class QDA implements SoftClassifier<double[]>, Serializable {
             }
             
             if (i > 0 && labels[i] - labels[i-1] > 1) {
-                throw new IllegalArgumentException("Missing class: " + labels[i]+1);                 
+                throw new IllegalArgumentException("Missing class: " + (labels[i-1]+1));
             }
         }
 

--- a/core/src/main/java/smile/classification/RBFNetwork.java
+++ b/core/src/main/java/smile/classification/RBFNetwork.java
@@ -288,7 +288,7 @@ public class RBFNetwork<T> implements Classifier<T>, Serializable {
             }
             
             if (i > 0 && labels[i] - labels[i-1] > 1) {
-                throw new IllegalArgumentException("Missing class: " + labels[i]+1);                 
+                throw new IllegalArgumentException("Missing class: " + (labels[i-1]+1));
             }
         }
 

--- a/core/src/main/java/smile/classification/RDA.java
+++ b/core/src/main/java/smile/classification/RDA.java
@@ -208,7 +208,7 @@ public class RDA implements SoftClassifier<double[]>, Serializable {
             }
             
             if (i > 0 && labels[i] - labels[i-1] > 1) {
-                throw new IllegalArgumentException("Missing class: " + labels[i]+1);                 
+                throw new IllegalArgumentException("Missing class: " + (labels[i-1]+1));
             }
         }
 

--- a/core/src/main/java/smile/classification/RandomForest.java
+++ b/core/src/main/java/smile/classification/RandomForest.java
@@ -632,7 +632,7 @@ public class RandomForest implements SoftClassifier<double[]>, Serializable {
             }
             
             if (i > 0 && labels[i] - labels[i-1] > 1) {
-                throw new IllegalArgumentException("Missing class: " + labels[i]+1);                 
+                throw new IllegalArgumentException("Missing class: " + (labels[i-1]+1));
             }
         }
 


### PR DESCRIPTION
When the labels vector are not in sequencial ordering, like: [1, 2, 4], the exception message was informing a wrong position, because was concatenating the String "Missing class: ", with the value of labels[i], and concatenating with number 1, in this example creating the String "Missing class: 41", where the correct should be "Missing class: 3".