### PR TITLE
Minor Typo in FastPair Method updateDistance

### DIFF
--- a/core/src/main/java/smile/clustering/FastPair.java
+++ b/core/src/main/java/smile/clustering/FastPair.java
@@ -217,14 +217,14 @@ class FastPair {
         float d = linkage.d(p, q);
 
         if (d < distance[p]) {
-            distance[p] = q;
+            distance[p] = d;
             neighbor[p] = q;
         } else if (neighbor[p] == q && d > distance[p]) {
             findNeighbor(p);
         }
 
         if (d < distance[q]) {
-            distance[q] = p;
+            distance[q] = d;
             neighbor[q] = p;
         } else if (neighbor[q] == p && d > distance[q]) {
             findNeighbor(q);


### PR DESCRIPTION
It appears that the distance array was incorrectly set the point index instead of the calculate linkage distance. Based on other usage of linkage distance in this class this appears to be the correct behavior.