### PR TITLE
[Proposal][Discuss] Accept general Matrix in train/predict

### DIFF
--- a/core/src/main/java/smile/classification/Classifier.java
+++ b/core/src/main/java/smile/classification/Classifier.java
@@ -16,6 +16,10 @@
 
 package smile.classification;
 
+import smile.math.matrix.DenseMatrix;
+import smile.math.matrix.Matrix;
+import smile.math.matrix.SparseMatrix;
+
 import java.io.Serializable;
 
 /**
@@ -44,6 +48,26 @@ public interface Classifier<T> extends Serializable {
      * @return the predicted class label.
      */
     int predict(T x);
+
+    default int[] predict(Matrix x) {
+        if (x instanceof DenseMatrix) {
+            return predict((DenseMatrix) x);
+        } else if (x instanceof SparseMatrix) {
+            return predict((SparseMatrix) x);
+        }
+        throw new UnsupportedOperationException();
+    }
+
+    @SuppressWarnings("unchecked")
+    default int[] predict(DenseMatrix x) {
+        double[][] aa = x.array();
+        T[] a = (T[]) aa;
+        return predict(a);
+    }
+
+    default int[] predict(SparseMatrix x) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Predicts the class labels of an array of instances.

--- a/core/src/main/java/smile/classification/ClassifierTrainer.java
+++ b/core/src/main/java/smile/classification/ClassifierTrainer.java
@@ -16,6 +16,9 @@
 package smile.classification;
 
 import smile.data.Attribute;
+import smile.math.matrix.DenseMatrix;
+import smile.math.matrix.Matrix;
+import smile.math.matrix.SparseMatrix;
 
 /**
  * Abstract classifier trainer.
@@ -54,6 +57,26 @@ public abstract class ClassifierTrainer <T> {
      */
     public void setAttributes(Attribute[] attributes) {
         this.attributes = attributes;
+    }
+
+    public Classifier<T> train(Matrix x, int[] y) {
+        if (x instanceof DenseMatrix) {
+            return train((DenseMatrix) x, y);
+        } else if( x instanceof SparseMatrix) {
+            return train((SparseMatrix) x, y);
+        }
+        throw new UnsupportedOperationException();
+    }
+
+    @SuppressWarnings("unchecked")
+    public Classifier<T> train(DenseMatrix x, int[] y) {
+        double[][] aa = x.array();
+        T[] a = (T[]) aa;
+        return train(a, y);
+    }
+
+    public Classifier<T> train(SparseMatrix x, int[] y) {
+        throw new UnsupportedOperationException();
     }
     
     /**

--- a/core/src/test/java/smile/classification/ClassifierTest.java
+++ b/core/src/test/java/smile/classification/ClassifierTest.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2010 Haifeng Li
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package smile.classification;
+
+import smile.math.matrix.JMatrix;
+import smile.math.matrix.Matrix;
+import smile.math.matrix.SparseMatrix;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClassifierTest {
+
+    @Test
+    public void testPredictDoubleArray() {
+        double[][] x = {{0.7220180, 0.07121225, 0.6881997}, {-0.2648886, -0.89044952, 0.3700456},
+                {-0.6391588, 0.44947578, 0.6240573}};
+
+        DummyClassifier classifier = new DummyClassifier();
+        classifier.predict(x);
+        Assert.assertEquals(1, classifier.count);
+    }
+
+    @Test
+    public void testPredictMatrix() {
+        double[][] x = {{0.7220180, 0.07121225, 0.6881997}, {-0.2648886, -0.89044952, 0.3700456},
+                {-0.6391588, 0.44947578, 0.6240573}};
+
+        DummyClassifier classifier = new DummyClassifier();
+        classifier.predict(new JMatrix(x));
+        classifier.predict((Matrix) new JMatrix(x));
+        Assert.assertEquals(2, classifier.count);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testPredictSparseMatrix() {
+        double[][] x = {{0.7220180, 0.07121225, 0.6881997}, {-0.2648886, -0.89044952, 0.3700456},
+                {-0.6391588, 0.44947578, 0.6240573}};
+
+        DummyClassifier classifier = new DummyClassifier();
+        classifier.predict(new SparseMatrix(x));
+        classifier.predict((Matrix) new SparseMatrix(x));
+
+        Assert.assertEquals(-2, classifier.count);
+    }
+
+    private static class DummyClassifier implements Classifier<double[]> {
+
+        int count = 0;
+
+        @Override
+        public int predict(double[] x) {
+            count++;
+
+            return 0;
+        }
+
+        @Override
+        public int[] predict(SparseMatrix x) {
+            count--;
+
+            return null;
+        }
+    }
+
+}

--- a/core/src/test/java/smile/classification/ClassifierTrainerTest.java
+++ b/core/src/test/java/smile/classification/ClassifierTrainerTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2010 Haifeng Li
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package smile.classification;
+
+import smile.math.matrix.DenseMatrix;
+import smile.math.matrix.JMatrix;
+import smile.math.matrix.Matrix;
+import smile.math.matrix.SparseMatrix;
+
+import java.io.IOException;
+import java.text.ParseException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClassifierTrainerTest {
+
+    @Test
+    public void testDoubleArrayForX() throws IOException, ParseException {
+        double[][] x = {{0.7220180, 0.07121225, 0.6881997}, {-0.2648886, -0.89044952, 0.3700456},
+                {-0.6391588, 0.44947578, 0.6240573}};
+        int[] y = {1, 2, 3};
+
+        DummyClassifierTrainer train = new DummyClassifierTrainer();
+        train.train(x, y);
+        Assert.assertEquals(1, train.count);
+    }
+
+    @Test
+    public void testMatrixForX() throws IOException, ParseException {
+        double[][] x = {{0.7220180, 0.07121225, 0.6881997}, {-0.2648886, -0.89044952, 0.3700456},
+                {-0.6391588, 0.44947578, 0.6240573}};
+        int[] y = {1, 2, 3};
+
+        DummyClassifierTrainer train = new DummyClassifierTrainer();
+        DenseMatrix X = new JMatrix(x);
+        train.train(X, y);
+        train.train((Matrix) X, y);
+        Assert.assertEquals(2, train.count);
+    }
+
+    @Test
+    public void testSparseMatrixForX() throws IOException, ParseException {
+        double[][] x = {{0.7220180, 0.07121225, 0.6881997}, {-0.2648886, -0.89044952, 0.3700456},
+                {-0.6391588, 0.44947578, 0.6240573}};
+        int[] y = {1, 2, 3};
+
+        DummyClassifierTrainer train = new DummyClassifierTrainer();
+        SparseMatrix X = new SparseMatrix(x);
+        train.train(X, y);
+        train.train((Matrix) X, y);
+        Assert.assertEquals(-2, train.count);
+    }
+
+    private static class DummyClassifierTrainer extends ClassifierTrainer<double[]> {
+
+        int count = 0;
+
+        @Override
+        public Classifier<double[]> train(double[][] x, int[] y) {
+            count++;
+            return null;
+        }
+
+        @Override
+        public Classifier<double[]> train(SparseMatrix x, int[] y) {
+            count--;
+            return null;
+        }
+
+    }
+
+}


### PR DESCRIPTION
How about accepting Matrix for train/predict?

I was willing to contribute [SparseMatrix supports in DecisionTree in addition to DenseMatrix](https://github.com/apache/incubator-hivemall/blob/master/core/src/main/java/hivemall/smile/classification/DecisionTree.java#L962
) but it introduces a lot of changes in interface and thus resigned to make a PR.

It would be better to discuss API design in advance and make a consensus. Here is a concept patch that works with the existing implementations.

Ideally, all algorithm overrides `Classifier<T> train(Matrix x, int[] y)` in the future.

Scikit support dense array as well as CSR sparse matrix for [fitting](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html#sklearn.linear_model.SGDClassifier.fit).