### PR TITLE
PartitionClustering should be Serializable

### DIFF
--- a/core/src/main/java/smile/clustering/PartitionClustering.java
+++ b/core/src/main/java/smile/clustering/PartitionClustering.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package smile.clustering;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import smile.math.Math;
 
@@ -26,7 +27,7 @@ import smile.math.Math;
  * 
  * @author Haifeng Li
  */
-public abstract class PartitionClustering <T> implements Clustering<T> {
+public abstract class PartitionClustering <T> implements Clustering<T>, Serializable {
     /**
      * The number of clusters.
      */


### PR DESCRIPTION
Hi

I'm trying to serialize a DBSCAN instance, store it on disk, and deserialize when needed in order to use the `predict` method. the goal is to evaluate new datapoints without recomputing everything.

The issue is that even if `DBSCAN<T>` is declared Serializable, its parent class PartitionClustering is not. So java serialization process will NOT serialize fields inherited from the parent class (`k`, `y`, `size`). That makes the deserialized class unusable since these values are lost.

This PR just add Serializable to the PartitionClustering class.