### PR TITLE
Prune redundant branches in DecisionTrees

### DIFF
--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -973,9 +973,6 @@ public class DecisionTree implements SoftClassifier<double[]> {
             }
         }
 
-        // Priority queue for best-first tree growing.
-        PriorityQueue<TrainNode> nextSplits = new PriorityQueue<>();
-
         int n = y.length;
         int[] count = new int[k];
         if (samples == null) {
@@ -1003,21 +1000,28 @@ public class DecisionTree implements SoftClassifier<double[]> {
         root = new Node(Math.whichMax(count), posteriori);
         
         TrainNode trainRoot = new TrainNode(root, x, y, samples, 0, originalOrder.length);
-        // Now add splits to the tree until max tree size is reached
-        if (trainRoot.findBestSplit()) {
-            nextSplits.add(trainRoot);
-        }
-
-        // Pop best leaf from priority queue, split it, and push
-        // children nodes into the queue if possible.
-        for (int leaves = 1; leaves < this.maxNodes; leaves++) {
-            // parent is the leaf to split
-            TrainNode node = nextSplits.poll();
-            if (node == null) {
-                break;
+        if(maxNodes == Integer.MAX_VALUE) {// depth-first split
+            if (trainRoot.findBestSplit()) {
+                trainRoot.split(null);
             }
+        } else {// best-first split
+            // Priority queue for best-first tree growing.
+            PriorityQueue<TrainNode> nextSplits = new PriorityQueue<>();
 
-            node.split(nextSplits); // Split the parent node into two children nodes
+            // Now add splits to the tree until max tree size is reached
+            if (trainRoot.findBestSplit()) {
+                nextSplits.add(trainRoot);
+            }
+            // Pop best leaf from priority queue, split it, and push
+            // children nodes into the queue if possible.
+            for (int leaves = 1; leaves < this.maxNodes; leaves++) {
+                // parent is the leaf to split
+                TrainNode node = nextSplits.poll();
+                if (node == null) {
+                    break;
+                }
+                node.split(nextSplits); // Split the parent node into two children nodes
+            }
         }
 
         this.order = null;

--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -328,6 +328,8 @@ public class DecisionTree implements SoftClassifier<double[]> {
             this.splitFeature = -1;
             this.splitValue = Double.NaN;
             this.splitScore = 0.0;
+            this.trueChild = null;
+            this.falseChild = null;
         }
 
         /**

--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -1020,7 +1020,9 @@ public class DecisionTree implements SoftClassifier<double[]> {
                 if (node == null) {
                     break;
                 }
-                node.split(nextSplits); // Split the parent node into two children nodes
+                if(!node.split(nextSplits)) { // Split the parent node into two children nodes
+                    leaves--;
+                }
             }
         }
 


### PR DESCRIPTION
I found that smile's decision tree produces a lot of redundant branches as seen in 
https://user-images.githubusercontent.com/1163783/27733149-8a1927d8-5dcf-11e7-873b-9f0d37e19733.png

So, this PR prune redundant branches as follows:

Before: 
```javascript
if( sibsp <= 2.5 ) {
  if( age <= 15.5 ) {
    if( age <= 0.5 ) {
      if( sibsp <= 1.5 ) {
        if( parch <= 1.5 ) {
          no;
        } else  {
          no;
        }
      } else  {
        yes;
      }
    } else  {
      if( age <= 11.5 ) {
        if( fare <= 14.33125 ) {
          yes;
        } else  {
          yes;
        }
      } else  {
        yes;
      }
    }
  } else  {
    no;
  }
} else  {
  no;
}
```

After:
```javascript
if( sibsp <= 2.5 ) {
  if( age <= 15.5 ) {
    if( age <= 0.5 ) {
      if( sibsp <= 1.5 ) {
        no;
      } else  {
        yes;
      }
    } else  {
      yes;
    }
  } else  {
    no;
  }
} else  {
  no;
}
```

This is a back-port of [my modification](https://github.com/apache/incubator-hivemall/pull/198) to smile.