### PR TITLE
Reduce size of DecisionTrees: remove unnecessary members; clear unuse…

### DIFF
--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -316,6 +316,14 @@ public class DecisionTree implements SoftClassifier<double[]> {
             this.posteriori = posteriori;
         }
 
+        private void markAsLeaf() {
+            this.splitFeature = -1;
+            this.splitValue = Double.NaN;
+            this.splitScore = 0.0;
+            this.trueChild = null;
+            this.falseChild = null;
+        }
+
         /**
          * Evaluate the regression tree over an instance.
          */
@@ -691,9 +699,7 @@ public class DecisionTree implements SoftClassifier<double[]> {
             }
 
             if (tc < nodeSize || fc < nodeSize) {
-                node.splitFeature = -1;
-                node.splitValue = Double.NaN;
-                node.splitScore = 0.0;
+                node.markAsLeaf();
                 return false;
             }
 
@@ -711,13 +717,18 @@ public class DecisionTree implements SoftClassifier<double[]> {
             int[] buffer = new int[high - split];
             partitionOrder(low, split, high, goesLeft, buffer);
 
+            int leaves = 0;
             TrainNode trueChild = new TrainNode(node.trueChild, x, y, samples, low, split);
             if (tc > nodeSize && trueChild.findBestSplit()) {
                 if (nextSplits != null) {
                     nextSplits.add(trueChild);
                 } else {
-                    trueChild.split(null);
+                    if (trueChild.split(null) == false) {
+                        leaves++;
+                    }
                 }
+            } else {
+                leaves++;
             }
 
             TrainNode falseChild = new TrainNode(node.falseChild, x, y, samples, split, high);
@@ -725,7 +736,19 @@ public class DecisionTree implements SoftClassifier<double[]> {
                 if (nextSplits != null) {
                     nextSplits.add(falseChild);
                 } else {
-                    falseChild.split(null);
+                    if (falseChild.split(null) == false) {
+                        leaves++;
+                    }
+                }
+            } else {
+                leaves++;
+            }
+
+            // Prune meaningless branches
+            if (leaves == 2) {// both left and right child is leaf node
+                if (node.trueChild.output == node.falseChild.output) {// found meaningless branch
+                    node.markAsLeaf();
+                    return false;
                 }
             }
 
@@ -938,9 +961,6 @@ public class DecisionTree implements SoftClassifier<double[]> {
             }
         }
 
-        // Priority queue for best-first tree growing.
-        PriorityQueue<TrainNode> nextSplits = new PriorityQueue<>();
-
         int n = y.length;
         int[] count = new int[k];
         if (samples == null) {
@@ -968,21 +988,30 @@ public class DecisionTree implements SoftClassifier<double[]> {
         root = new Node(Math.whichMax(count), posteriori);
         
         TrainNode trainRoot = new TrainNode(root, x, y, samples, 0, originalOrder.length);
-        // Now add splits to the tree until max tree size is reached
-        if (trainRoot.findBestSplit()) {
-            nextSplits.add(trainRoot);
-        }
-
-        // Pop best leaf from priority queue, split it, and push
-        // children nodes into the queue if possible.
-        for (int leaves = 1; leaves < this.maxNodes; leaves++) {
-            // parent is the leaf to split
-            TrainNode node = nextSplits.poll();
-            if (node == null) {
-                break;
+        if(maxNodes == Integer.MAX_VALUE) {// depth-first split
+            if (trainRoot.findBestSplit()) {
+                trainRoot.split(null);
             }
+        } else {// best-first split
+            // Priority queue for best-first tree growing.
+            PriorityQueue<TrainNode> nextSplits = new PriorityQueue<>();
 
-            node.split(nextSplits); // Split the parent node into two children nodes
+            // Now add splits to the tree until max tree size is reached
+            if (trainRoot.findBestSplit()) {
+                nextSplits.add(trainRoot);
+            }
+            // Pop best leaf from priority queue, split it, and push
+            // children nodes into the queue if possible.
+            for (int leaves = 1; leaves < this.maxNodes; leaves++) {
+                // parent is the leaf to split
+                TrainNode node = nextSplits.poll();
+                if (node == null) {
+                    break;
+                }
+                if (!node.split(nextSplits)) { // Split the parent node into two children nodes
+                    leaves--;
+                }
+            }
         }
 
         pruneRedundantLeaves(root);

--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -753,7 +753,14 @@ public class DecisionTree implements SoftClassifier<double[]> {
             }
 
             importance[node.splitFeature] += node.splitScore;
-            
+
+            if (nextSplits == null) {
+                // We're doing depth-first splitting, so this node is definitely an interior node
+                // and its posteriori array can be deleted. For best-first splitting, these are
+                // cleared in pruneRedundantLeaves.
+                node.posteriori = null;
+            }
+
             return true;
         }
     }
@@ -1012,9 +1019,8 @@ public class DecisionTree implements SoftClassifier<double[]> {
                     leaves--;
                 }
             }
+            pruneRedundantLeaves(root);
         }
-
-        pruneRedundantLeaves(root);
 
         this.order = null;
         this.originalOrder = null;

--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -301,14 +301,6 @@ public class DecisionTree implements SoftClassifier<double[]> {
          * Children node.
          */
         Node falseChild = null;
-        /**
-         * Predicted output for children node.
-         */
-        int trueChildOutput = -1;
-        /**
-         * Predicted output for children node.
-         */
-        int falseChildOutput = -1;
 
         /**
          * Constructor.
@@ -328,7 +320,7 @@ public class DecisionTree implements SoftClassifier<double[]> {
          * Evaluate the regression tree over an instance.
          */
         public int predict(double[] x) {
-            if (trueChild == null && falseChild == null) {
+            if (isLeaf()) {
                 return output;
             } else {
                 if (attributes[splitFeature].getType() == Attribute.Type.NOMINAL) {
@@ -353,7 +345,7 @@ public class DecisionTree implements SoftClassifier<double[]> {
          * Evaluate the regression tree over an instance.
          */
         public int predict(double[] x, double[] posteriori) {
-            if (trueChild == null && falseChild == null) {
+            if (isLeaf()) {
                 System.arraycopy(this.posteriori, 0, posteriori, 0, k);
                 return output;
             } else {
@@ -373,6 +365,10 @@ public class DecisionTree implements SoftClassifier<double[]> {
                     throw new IllegalStateException("Unsupported attribute type: " + attributes[splitFeature].getType());
                 }
             }
+        }
+
+        boolean isLeaf() {
+            return falseChild == null;
         }
     }
 
@@ -526,8 +522,6 @@ public class DecisionTree implements SoftClassifier<double[]> {
                         node.splitFeature = split.splitFeature;
                         node.splitValue = split.splitValue;
                         node.splitScore = split.splitScore;
-                        node.trueChildOutput = split.trueChildOutput;
-                        node.falseChildOutput = split.falseChildOutput;
                     }
                 }
             } else {
@@ -543,8 +537,6 @@ public class DecisionTree implements SoftClassifier<double[]> {
                             node.splitFeature = split.splitFeature;
                             node.splitValue = split.splitValue;
                             node.splitScore = split.splitScore;
-                            node.trueChildOutput = split.trueChildOutput;
-                            node.falseChildOutput = split.falseChildOutput;
                         }
                     }
                 } catch (Exception ex) {
@@ -555,8 +547,6 @@ public class DecisionTree implements SoftClassifier<double[]> {
                             node.splitFeature = split.splitFeature;
                             node.splitValue = split.splitValue;
                             node.splitScore = split.splitScore;
-                            node.trueChildOutput = split.trueChildOutput;
-                            node.falseChildOutput = split.falseChildOutput;
                         }
                     }
                 }
@@ -607,8 +597,6 @@ public class DecisionTree implements SoftClassifier<double[]> {
                         splitNode.splitFeature = j;
                         splitNode.splitValue = l;
                         splitNode.splitScore = gain;
-                        splitNode.trueChildOutput = Math.whichMax(trueCount[l]);
-                        splitNode.falseChildOutput = Math.whichMax(falseCount);
                     }
                 }
             } else if (attributes[j].getType() == Attribute.Type.NUMERIC) {
@@ -648,8 +636,6 @@ public class DecisionTree implements SoftClassifier<double[]> {
                         splitNode.splitFeature = j;
                         splitNode.splitValue = (x[o][j] + prevx) / 2;
                         splitNode.splitScore = gain;
-                        splitNode.trueChildOutput = Math.whichMax(trueCount);
-                        splitNode.falseChildOutput = Math.whichMax(falseCount);
                     }
 
                     prevx = x[o][j];
@@ -711,14 +697,16 @@ public class DecisionTree implements SoftClassifier<double[]> {
                 return false;
             }
 
+            int trueChildOutput = Math.whichMax(trueChildPosteriori);
+            int falseChildOutput = Math.whichMax(falseChildPosteriori);
             // add-k smoothing of posteriori probability
             for (int i = 0; i < k; i++) {
                 trueChildPosteriori[i] = (trueChildPosteriori[i] + 1) / (tc + k);
                 falseChildPosteriori[i] = (falseChildPosteriori[i] + 1) / (fc + k);
             }
 
-            node.trueChild = new Node(node.trueChildOutput, trueChildPosteriori);
-            node.falseChild = new Node(node.falseChildOutput, falseChildPosteriori);
+            node.trueChild = new Node(trueChildOutput, trueChildPosteriori);
+            node.falseChild = new Node(falseChildOutput, falseChildPosteriori);
 
             int[] buffer = new int[high - split];
             partitionOrder(low, split, high, goesLeft, buffer);
@@ -997,6 +985,8 @@ public class DecisionTree implements SoftClassifier<double[]> {
             node.split(nextSplits); // Split the parent node into two children nodes
         }
 
+        pruneRedundantLeaves(root);
+
         this.order = null;
         this.originalOrder = null;
     }
@@ -1108,6 +1098,31 @@ public class DecisionTree implements SoftClassifier<double[]> {
     }
 
     /**
+     * Prunes redundant leaves from the tree. In some cases, a node is split into two leaves that
+     * get assigned the same label, so this recursively combines leaves when it notices this
+     * situation.
+     */
+    private void pruneRedundantLeaves(Node node) {
+        if (node.isLeaf()) {
+            return;
+        }
+
+        // The children might not be leaves now, but might collapse into leaves given the chance.
+        pruneRedundantLeaves(node.trueChild);
+        pruneRedundantLeaves(node.falseChild);
+
+        if (node.trueChild.isLeaf() && node.falseChild.isLeaf() &&
+            node.trueChild.output == node.falseChild.output) {
+            node.trueChild = null;
+            node.falseChild = null;
+            importance[node.splitFeature] -= node.splitScore;
+        } else {
+            // This is an interior node, and will remain so. Its posteriori array is dead weight.
+            node.posteriori = null;
+        }
+    }
+
+    /**
      * Returns the variable importance. Every time a split of a node is made
      * on variable the (GINI, information gain, etc.) impurity criterion for
      * the two descendent nodes is less than the parent node. Adding up the
@@ -1191,7 +1206,7 @@ public class DecisionTree implements SoftClassifier<double[]> {
             Node node = dnode.node;
 
             // leaf node
-            if (node.trueChild == null && node.falseChild == null) {
+            if (node.isLeaf()) {
                 builder.append(String.format(" %d [label=<class = %d>, fillcolor=\"#00000000\", shape=ellipse];\n", id, node.output));
             } else {
                 Attribute attr = attributes[node.splitFeature];

--- a/core/src/test/java/smile/classification/DecisionTreeTest.java
+++ b/core/src/test/java/smile/classification/DecisionTreeTest.java
@@ -208,7 +208,7 @@ public class DecisionTreeTest {
                 System.out.format("%s importance is %.4f%n", train.attributes()[index[i]], importance[i]);
             }
             
-            assertEquals(324, error);
+            assertEquals(322, error);
         } catch (Exception ex) {
             System.err.println(ex);
         }


### PR DESCRIPTION
This uses three techniques to reduce the in-RAM (and on-disk, when serialised) size of DecisionTrees.
1. Remove two members that are used only during training.
2. Clear the "importance" array on interior nodes, as it's used only on leaves and can be quite large if there are many classes.
3. As suggested by myui, remove splits where both sides have the same label.

A couple of important notes:
- This conflicts with https://github.com/haifengl/smile/pull/449. It does a more general job of pruning by waiting until the tree is fully constructed so that multiple levels that all have the same label can be merged.
- This changes the list of non-transient members of Node, which will affect its autogenerated serialVersionUID, so any serialised DecisionTrees generated from old code will not be readable in new code and vice versa. The changes are such that I believe that inserting an explicit serialVersionUID equal to the current autogenerated one will actually give us forward and backward compatibility, but whether to do that is a decision that I don't want to make.

On the "airline-100k" benchmark, this reduces the serialised size of the RandomForest from ~6M to ~2.4M, mostly due to the pruning; on an internal benchmark, it goes from ~50M to ~26M, mostly due to the removal of importance arrays on interior nodes.