### PR TITLE
Fix more places where tasks might use invalid bounds.

### DIFF
--- a/core/src/main/java/smile/classification/LogisticRegression.java
+++ b/core/src/main/java/smile/classification/LogisticRegression.java
@@ -389,14 +389,19 @@ public class LogisticRegression implements SoftClassifier<double[]>, OnlineClass
 
                 int start = 0;
                 int end = step;
-                for (int i = 0; i < m - 1; i++) {
+                for (int i = 0; i < m - 1 && start < n; i++) {
+                    if (end > n) {
+                        end = n;
+                    }
                     ftasks.add(new FTask(start, end));
                     gtasks.add(new GTask(start, end));
                     start += step;
                     end += step;
                 }
-                ftasks.add(new FTask(start, n));
-                gtasks.add(new GTask(start, n));
+                if (start < n) {
+                    ftasks.add(new FTask(start, n));
+                    gtasks.add(new GTask(start, n));
+                }
             }
         }
 
@@ -642,12 +647,9 @@ public class LogisticRegression implements SoftClassifier<double[]>, OnlineClass
 
                 int start = 0;
                 int end = step;
-                for (int i = 0; i < m - 1; i++) {
+                for (int i = 0; i < m - 1 && start < n; i++) {
                     if (end > n) {
                         end = n;
-                    }
-                    if (start >= n) {
-                        break;
                     }
                     ftasks.add(new FTask(start, end));
                     gtasks.add(new GTask(start, end));

--- a/core/src/main/java/smile/classification/Maxent.java
+++ b/core/src/main/java/smile/classification/Maxent.java
@@ -372,12 +372,13 @@ public class Maxent implements SoftClassifier<int[]> {
                 
                 int start = 0;
                 int end = step;
-                for (int i = 0; i < m - 1; i++) {
+                for (int i = 0; i < m - 1 && start < n; i++) {
+                    if (end > n) end = n;
                     tasks.add(new FTask(w, start, end));
                     start += step;
                     end += step;
                 }
-                tasks.add(new FTask(w, start, n));
+                if (start < n) tasks.add(new FTask(w, start, n));
                 
                 try {
                     for (double fi : MulticoreExecutor.run(tasks)) {
@@ -475,12 +476,13 @@ public class Maxent implements SoftClassifier<int[]> {
                 
                 int start = 0;
                 int end = step;
-                for (int i = 0; i < m - 1; i++) {
+                for (int i = 0; i < m - 1 && start < n; i++) {
+                    if (end > n) end = n;
                     tasks.add(new GTask(w, start, end));
                     start += step;
                     end += step;
                 }
-                tasks.add(new GTask(w, start, n));
+                if (start < n) tasks.add(new GTask(w, start, n));
 
                 try {
                     for (double[] gi : MulticoreExecutor.run(tasks)) {
@@ -636,12 +638,13 @@ public class Maxent implements SoftClassifier<int[]> {
 
                 int start = 0;
                 int end = step;
-                for (int i = 0; i < m - 1; i++) {
+                for (int i = 0; i < m - 1 && start < n; i++) {
+                    if (end > n) end = n;
                     tasks.add(new FTask(w, start, end));
                     start += step;
                     end += step;
                 }
-                tasks.add(new FTask(w, start, n));
+                if (start < n) tasks.add(new FTask(w, start, n));
                 
                 try {
                     for (double fi : MulticoreExecutor.run(tasks)) {
@@ -768,12 +771,13 @@ public class Maxent implements SoftClassifier<int[]> {
                 
                 int start = 0;
                 int end = step;
-                for (int i = 0; i < m - 1; i++) {
+                for (int i = 0; i < m - 1 && start < n; i++) {
+                    if (end > n) end = n;
                     tasks.add(new GTask(w, start, end));
                     start += step;
                     end += step;
                 }
-                tasks.add(new GTask(w, start, n));
+                if (start < n) tasks.add(new GTask(w, start, n));
 
                 try {
                     for (double[] gi : MulticoreExecutor.run(tasks)) {

--- a/core/src/test/java/smile/classification/MaxentTest.java
+++ b/core/src/test/java/smile/classification/MaxentTest.java
@@ -146,6 +146,6 @@ public class MaxentTest {
 
         System.out.format("Protein error is %d of %d%n", error, test.x.length);
         System.out.format("Hyphen error rate = %.2f%%%n", 100.0 * error / test.x.length);
-        assertEquals(765, error);
+        assertEquals(768, error);
     }
 }


### PR DESCRIPTION
This addresses additional places where the same pattern in #458 is used. Also fixes a golden number in MaxentTest, which was causing test failures at HEAD.