### PR TITLE
Avoid constant features in findBestSplit

### DIFF
--- a/core/src/main/java/smile/classification/DecisionTree.java
+++ b/core/src/main/java/smile/classification/DecisionTree.java
@@ -559,7 +559,7 @@ public class DecisionTree implements SoftClassifier<double[]> {
             } else {
 
                 final int[] constFeatures_;
-                synchronized (constFeatures) {
+                synchronized (this.constFeatures) {// enforce to read up-to-date constFeature
                     constFeatures_ = this.constFeatures; // this.constFeatures may be replaced in findBestSplit but it's accepted
                 }
                 List<SplitTask> tasks = new ArrayList<>(mtry);
@@ -719,9 +719,9 @@ public class DecisionTree implements SoftClassifier<double[]> {
             }
 
             if(replaceCount + (countNaN > 0 ? 1: 0) <= 1) {
-                synchronized (constFeatures) {
-                    this.constFeatures = SmileUtils.sortedArraySet(constFeatures, j);
-                }
+                synchronized (this.constFeatures) { // enforce to read up-to-date constFeatures
+                    this.constFeatures = SmileUtils.sortedArraySet(this.constFeatures, j);
+                } // this.constFeatures in CPU cache is flushed
             }
 
             return splitNode;

--- a/core/src/main/java/smile/util/SmileUtils.java
+++ b/core/src/main/java/smile/util/SmileUtils.java
@@ -38,6 +38,46 @@ public class SmileUtils {
     }
 
     /**
+     * Insert an element to the given sorted array at the right position.
+     *
+     * @param sorted sorted array
+     * @param element element to add
+     * @return sorted array with an element inserted
+     */
+    public static int[] sortedArraySet(final int[] sorted, final int element) {
+        final int i = Arrays.binarySearch(sorted, element);
+        if (i >= 0) {// found element
+            return sorted;
+        } else {
+            return insert(sorted, ~i, element);
+        }
+    }
+
+    /**
+     * Insert the given element at the specified index of the given array.
+     *
+     * @param array original array
+     * @param index index to add an element
+     * @param element element to add
+     * @return an expanded array with an element inserted
+     */
+    public static int[] insert(final int[] array, final int index, final int element) {
+        final int size = array.length;
+        if (index > size) {
+            throw new IllegalArgumentException(String.format(
+                "index should be less than or equals to array.length: index=%d, array.length=%d",
+                index, array.length));
+        }
+        final int[] newArray = new int[size + 1];
+        System.arraycopy(array, 0, newArray, 0, Math.min(index, size));
+        newArray[index] = element;
+        if (index != size) {
+            System.arraycopy(array, index, newArray, index + 1, size - index);
+        }
+        return newArray;
+    }
+
+    /**
      * Sorts each variable and returns the index of values in ascending order.
      * Only numeric attributes will be sorted. Note that the order of original
      * array is NOT altered.


### PR DESCRIPTION
This PR avoids constant features in finding best split.

Here is [a quote from scikit](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/tree/_splitter.pyx#L1455).

```
Skip the CPU intensive evaluation of the impurity criterion for features that were already detected as constant (hence not suitable for good splitting) by ancestor nodes and save the information on newly discovered constant features to spare computation on descendant nodes.
```

Not ideal but works well enough for multi-threaded execution as well.

This is a backport from [my smile modification](https://github.com/apache/incubator-hivemall/pull/198). 