### PR TITLE
Make random forest training deterministic.

### DIFF
--- a/core/src/main/java/smile/classification/RandomForest.java
+++ b/core/src/main/java/smile/classification/RandomForest.java
@@ -318,6 +318,11 @@ public class RandomForest implements SoftClassifier<double[]> {
          * The out-of-bag predictions.
          */
         int[][] prediction;
+        /**
+         * The RNG seed to use when running the task. Used to make sure that training is
+         * deterministic, even when multi-threading.
+         */
+        int rngSeed;
 
         /**
          * Constructor.
@@ -334,6 +339,7 @@ public class RandomForest implements SoftClassifier<double[]> {
             this.classWeight = classWeight;
             this.order = order;
             this.prediction = prediction;
+            this.rngSeed = Math.randomInt(Integer.MAX_VALUE);
         }
 
         @Override
@@ -341,6 +347,7 @@ public class RandomForest implements SoftClassifier<double[]> {
             int n = x.length;
             int k = smile.math.Math.max(y) + 1;
             int[] samples = new int[n];
+            Math.setSeed(rngSeed);
 
             // Stratified sampling in case class is unbalanced.
             // That is, we sample each class separately.

--- a/core/src/main/java/smile/regression/RandomForest.java
+++ b/core/src/main/java/smile/regression/RandomForest.java
@@ -276,6 +276,11 @@ public class RandomForest implements Regression<double[]> {
          * Out-of-bag sample
          */
         int[] oob;
+        /**
+         * The RNG seed to use when running the task. Used to make sure that training is
+         * deterministic, even when multi-threading.
+         */
+        int rngSeed;
 
         /**
          * Constructor.
@@ -292,12 +297,14 @@ public class RandomForest implements Regression<double[]> {
             this.subsample = subsample;
             this.prediction = prediction;
             this.oob = oob;
+            this.rngSeed = Math.randomInt(Integer.MAX_VALUE);
         }
 
         @Override
         public RegressionTree call() {
             int n = x.length;
             int[] samples = new int[n];
+            Math.setSeed(rngSeed);
 
             if (subsample == 1.0) {
                 // Training samples draw with replacement.

--- a/core/src/test/java/smile/classification/RandomForestTest.java
+++ b/core/src/test/java/smile/classification/RandomForestTest.java
@@ -225,4 +225,26 @@ public class RandomForestTest {
             System.err.println(ex);
         }
     }
+
+    /**
+     * Tests that RNG seeding consistently controls the trainig.
+     */
+    @Test
+    public void testSeeding() throws Exception {
+        System.out.println("Seeding");
+        ArffParser arffParser = new ArffParser();
+        arffParser.setResponseIndex(4);
+        AttributeDataset iris = arffParser.parse(smile.data.parser.IOUtils.getTestDataFile("weka/iris.arff"));
+        double[][] x = iris.toArray(new double[iris.size()][]);
+        int[] y = iris.toArray(new int[iris.size()]);
+
+        Math.setSeed(123);
+        RandomForest forest1 = new RandomForest(iris.attributes(), x, y, 100);
+        Math.setSeed(123);
+        RandomForest forest2 = new RandomForest(iris.attributes(), x, y, 100);
+
+        for (int i = 0; i < x.length; i++) {
+            assertEquals(forest1.predict(x[i]), forest2.predict(x[i]));
+        }
+    }
 }

--- a/core/src/test/java/smile/regression/RandomForestTest.java
+++ b/core/src/test/java/smile/regression/RandomForestTest.java
@@ -23,6 +23,7 @@ import smile.sort.QuickSort;
 import smile.validation.CrossValidation;
 import smile.validation.LOOCV;
 import smile.validation.Validation;
+import static org.junit.Assert.*;
 
 /**
  *
@@ -239,4 +240,27 @@ public class RandomForestTest {
         System.out.format("Merged RMSE = %.4f%n", Validation.test(merged, testx, testy));
     }
 
+    /**
+     * Tests that RNG seeding consistently controls the trainig.
+     */
+    @Test
+    public void testSeeding() throws Exception {
+        System.out.println("Seeding");
+        ArffParser parser = new ArffParser();
+        parser.setResponseIndex(6);
+        AttributeDataset data = parser.parse(smile.data.parser.IOUtils.getTestDataFile("weka/cpu.arff"));
+        double[] datay = data.toArray(new double[data.size()]);
+        double[][] datax = data.toArray(new double[data.size()][]);
+
+        Math.setSeed(123);
+        RandomForest forest1 = new RandomForest(data.attributes(), datax, datay, 100);
+        Math.setSeed(123);
+        RandomForest forest2 = new RandomForest(data.attributes(), datax, datay, 100);
+
+        for (int i = 0; i < datax.length; i++) {
+            // Training should have proceeded identically, so exact floating-point equality is
+            // reasonable to expect.
+            assertEquals(forest1.predict(datax[i]), forest2.predict(datax[i]), 0.0);
+        }
+    }
 }

--- a/shell/src/universal/doc/faq-content.html
+++ b/shell/src/universal/doc/faq-content.html
@@ -163,30 +163,11 @@
         This is a common question for stochastic algorithms like random forest.
         In general, this is discouraged because people often choose bad seed due to the lack
         of sufficient knowledge of random number generation. However, one may want the repeatable
-        result for testing purpose. In this case, the short answer is that set
-        <code>-Dsmile.threads=1</code> for JVM and call <code>smile.math.Math.setSeed</code> before
-        training the model. Again, if you just want repeatable result, the first step should be sufficient.
+        result for testing purpose. In this case, the short answer is
+        that you can call <code>smile.math.Math.setSeed</code> before
+        training the model. This works even when multithreaded
+        training is used.
     </p>
-
-    <p>
-        Note that we don't provide a method to set the seed for a particular algorithm.
-        Many algorithms are multithreaded and each thread has their own random number
-        generator. We choose this design because each random number generator maintains
-        an internal state so that it is not multithread-safe. If multithreads share a
-        random number generator, we have to use locks, which significant reduce the
-        performance.
-    </p>
-
-    <p>
-        A method <code>setSeed(double)</code> in the algorithm is also troublesome.
-        For algorithms like random forest, it is not right to initialize every thread
-        with the same seed. Otherwise, same decision trees will be created
-        and we lose the randomness of "random" forest. It is also complicated
-        to pass a sequence of random numbers because it is not clear
-        how many random number generators are needed for many algorithms. Even worse, it breaks
-        the encapsulation as the caller has to know the details of algorithms.
-    </p>
-
 </div>
 
 <script type="text/javascript">


### PR DESCRIPTION
This PR makes each tree in the random forest use a deterministically seeded RNG, using different seeds for each tree. It does this for classification and regression random forests. It also updates the FAQ answer for this question. The run-time cost of this change should be quite low, as no locks are needed, just a single RNG re-seed per tree.