### PR TITLE
Fix floating point comparison error in Beta#regularizedIncompleteBetaFunction

### DIFF
--- a/core/src/test/java/smile/regression/RidgeRegressionTest.java
+++ b/core/src/test/java/smile/regression/RidgeRegressionTest.java
@@ -185,4 +185,27 @@ public class RidgeRegressionTest {
              System.err.println(ex);
         }
     }
+
+    @Test
+    public void testFloatingPointComparisonError() {
+        // These inputs result in Beta#regularizedIncompleteBetaFunction
+        // being provided with x-value of 1.000000000000001.
+        // Beta.regularizedIncompleteBetaFunction(0.5 * 5, 0.5 * 2, 5 / (5 + 2 * -2.6928402123470195E-15));
+        double[][] xValues = {
+                { -1.6186802663701534E7, 1.5394863704190075E9 },
+                { 1.8990838567327976E8, 1.4302105368610876E9 },
+                { 3.96003574010262E8, 1.3209347033031676E9 },
+                { 6.020987623472443E8, 1.2116588697452476E9 },
+                { 8.081939506842256E8, 1.1023830361873276E9 },
+                { 1.0142891390212078E9, 9.931072026294076E8 },
+                { 1.22038432735819E9, 8.838313690714877E8 },
+                { 1.4264795156951709E9, 7.745555355135677E8 },
+        };
+        double[] yValues =
+                { -1.9367312273661723E9, -2.0487128915354834E9, -2.124363122479608E9, -2.162488870865301E9,
+                        -2.162488870865301E9, -2.1243631224796085E9, -2.0487128915354834E9, -1.9367312273661723E9 };
+
+        // Just test that this doesn't result in an error
+        new RidgeRegression(xValues, yValues, 3.0);
+    }
 }

--- a/math/src/main/java/smile/math/special/Beta.java
+++ b/math/src/main/java/smile/math/special/Beta.java
@@ -54,15 +54,16 @@ public class Beta {
      * Continued Fraction approximation (see Numerical recipies for details)
      */
     public static double regularizedIncompleteBetaFunction(double alpha, double beta, double x) {
-        if (x < 0.0 || x > 1.0) {
+        double EPS = 1e-8;
+        if (x + EPS < 0.0 || x - EPS > 1.0) {
             throw new IllegalArgumentException("Invalid x: " + x);
         }
 
         double ibeta = 0.0;
-        if (x == 0.0) {
+        if (Math.abs(x - 0.0) < EPS) {
             ibeta = 0.0;
         } else {
-            if (x == 1.0) {
+            if (Math.abs(x - 1.0) < EPS) {
                 ibeta = 1.0;
             } else {
                 // Term before continued fraction

--- a/math/src/main/java/smile/math/special/Beta.java
+++ b/math/src/main/java/smile/math/special/Beta.java
@@ -59,23 +59,22 @@ public class Beta {
             throw new IllegalArgumentException("Invalid x: " + x);
         }
 
-        double ibeta = 0.0;
         if (Math.abs(x - 0.0) < EPS) {
-            ibeta = 0.0;
+            return 0.0;
+        }
+
+        if (Math.abs(x - 1.0) < EPS) {
+            return 1.0;
+        }
+
+        // Term before continued fraction
+        double ibeta = Math.exp(Gamma.lgamma(alpha + beta) - Gamma.lgamma(alpha) - Gamma.lgamma(beta) + alpha * Math.log(x) + beta * Math.log(1.0D - x));
+        // Continued fraction
+        if (x < (alpha + 1.0) / (alpha + beta + 2.0)) {
+            ibeta = ibeta * incompleteFractionSummation(alpha, beta, x) / alpha;
         } else {
-            if (Math.abs(x - 1.0) < EPS) {
-                ibeta = 1.0;
-            } else {
-                // Term before continued fraction
-                ibeta = Math.exp(Gamma.lgamma(alpha + beta) - Gamma.lgamma(alpha) - Gamma.lgamma(beta) + alpha * Math.log(x) + beta * Math.log(1.0D - x));
-                // Continued fraction
-                if (x < (alpha + 1.0) / (alpha + beta + 2.0)) {
-                    ibeta = ibeta * incompleteFractionSummation(alpha, beta, x) / alpha;
-                } else {
-                    // Use symmetry relationship
-                    ibeta = 1.0 - ibeta * incompleteFractionSummation(beta, alpha, 1.0 - x) / beta;
-                }
-            }
+            // Use symmetry relationship
+            ibeta = 1.0 - ibeta * incompleteFractionSummation(beta, alpha, 1.0 - x) / beta;
         }
         return ibeta;
     }

--- a/math/src/test/java/smile/math/special/BetaTest.java
+++ b/math/src/test/java/smile/math/special/BetaTest.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2010 Haifeng Li
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package smile.math.special;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author Haifeng Li
+ */
+public class GammaTest {
+
+    public GammaTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Test of gamma method, of class Gamma.
+     */
+    @Test
+    public void testGamma() {
+        System.out.println("gamma");
+        assertTrue(Double.isInfinite(Gamma.gamma(0)));
+
+        assertEquals(1.0, Gamma.gamma(1), 1E-7);
+        assertEquals(1.0, Gamma.gamma(2), 1E-7);
+        assertEquals(2.0, Gamma.gamma(3), 1E-7);
+        assertEquals(6.0, Gamma.gamma(4), 1E-7);
+
+        assertEquals(0.886227, Gamma.gamma(1.5), 1E-6);
+        assertEquals(1.329340, Gamma.gamma(2.5), 1E-6);
+        assertEquals(3.323351, Gamma.gamma(3.5), 1E-6);
+        assertEquals(11.63173, Gamma.gamma(4.5), 1E-5);
+    }
+
+    /**
+     * Test of lgamma method, of class Gamma.
+     */
+    @Test
+    public void testLogGamma() {
+        System.out.println("lgamma");
+        assertTrue(Double.isInfinite(Gamma.lgamma(0)));
+
+        assertEquals(0.0, Gamma.lgamma(1), 1E-7);
+        assertEquals(0, Gamma.lgamma(2), 1E-7);
+        assertEquals(Math.log(2.0), Gamma.lgamma(3), 1E-7);
+        assertEquals(Math.log(6.0), Gamma.lgamma(4), 1E-7);
+
+        assertEquals(-0.1207822, Gamma.lgamma(1.5), 1E-7);
+        assertEquals(0.2846829, Gamma.lgamma(2.5), 1E-7);
+        assertEquals(1.200974, Gamma.lgamma(3.5), 1E-6);
+        assertEquals(2.453737, Gamma.lgamma(4.5), 1E-6);
+    }
+
+    /**
+     * Test of incompleteGamma method, of class Gamma.
+     */
+    @Test
+    public void testIncompleteGamma() {
+        System.out.println("incompleteGamma");
+        assertEquals(0.7807, Gamma.regularizedIncompleteGamma(2.1, 3), 1E-4);
+        assertEquals(0.3504, Gamma.regularizedIncompleteGamma(3, 2.1), 1E-4);
+    }
+
+    /**
+     * Test of upperIncompleteGamma method, of class Gamma.
+     */
+    @Test
+    public void testUpperIncompleteGamma() {
+        System.out.println("incompleteGamma");
+        assertEquals(0.2193, Gamma.regularizedUpperIncompleteGamma(2.1, 3), 1E-4);
+        assertEquals(0.6496, Gamma.regularizedUpperIncompleteGamma(3, 2.1), 1E-4);
+    }
+}

--- a/math/src/test/java/smile/math/special/BetaTest.java
+++ b/math/src/test/java/smile/math/special/BetaTest.java
@@ -16,93 +16,37 @@
 
 package smile.math.special;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
-import static org.junit.Assert.*;
 
-/**
- *
- * @author Haifeng Li
- */
-public class GammaTest {
-
-    public GammaTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
+public class BetaTest {
+    /**
+     * Test that a value of x above the upper boundary throws exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testRegularizedIncompleteBetaFunctionXBeyondUpperBoundary() {
+        Beta.regularizedIncompleteBetaFunction(1, 1, 1.00001);
     }
 
     /**
-     * Test of gamma method, of class Gamma.
+     * Test that a value of x below the lower boundary throws exception
      */
-    @Test
-    public void testGamma() {
-        System.out.println("gamma");
-        assertTrue(Double.isInfinite(Gamma.gamma(0)));
-
-        assertEquals(1.0, Gamma.gamma(1), 1E-7);
-        assertEquals(1.0, Gamma.gamma(2), 1E-7);
-        assertEquals(2.0, Gamma.gamma(3), 1E-7);
-        assertEquals(6.0, Gamma.gamma(4), 1E-7);
-
-        assertEquals(0.886227, Gamma.gamma(1.5), 1E-6);
-        assertEquals(1.329340, Gamma.gamma(2.5), 1E-6);
-        assertEquals(3.323351, Gamma.gamma(3.5), 1E-6);
-        assertEquals(11.63173, Gamma.gamma(4.5), 1E-5);
+    @Test(expected = IllegalArgumentException.class)
+    public void testRegularizedIncompleteBetaFunctionXBeyondLowerBoundary() {
+        Beta.regularizedIncompleteBetaFunction(1, 1, -0.00001);
     }
 
     /**
-     * Test of lgamma method, of class Gamma.
+     * Test that values of x within a reasonable distance from 0 and 1 are treated as 0 and 1,
+     * to account for floating point errors.
      */
     @Test
-    public void testLogGamma() {
-        System.out.println("lgamma");
-        assertTrue(Double.isInfinite(Gamma.lgamma(0)));
+    public void testRegularizedIncompleteBetaFunctionXWithinBoundaries() {
+        double pHigh = Beta.regularizedIncompleteBetaFunction(1, 1, 1.000000000000001);
+        assertEquals(1.0, pHigh, 0.0);
 
-        assertEquals(0.0, Gamma.lgamma(1), 1E-7);
-        assertEquals(0, Gamma.lgamma(2), 1E-7);
-        assertEquals(Math.log(2.0), Gamma.lgamma(3), 1E-7);
-        assertEquals(Math.log(6.0), Gamma.lgamma(4), 1E-7);
-
-        assertEquals(-0.1207822, Gamma.lgamma(1.5), 1E-7);
-        assertEquals(0.2846829, Gamma.lgamma(2.5), 1E-7);
-        assertEquals(1.200974, Gamma.lgamma(3.5), 1E-6);
-        assertEquals(2.453737, Gamma.lgamma(4.5), 1E-6);
-    }
-
-    /**
-     * Test of incompleteGamma method, of class Gamma.
-     */
-    @Test
-    public void testIncompleteGamma() {
-        System.out.println("incompleteGamma");
-        assertEquals(0.7807, Gamma.regularizedIncompleteGamma(2.1, 3), 1E-4);
-        assertEquals(0.3504, Gamma.regularizedIncompleteGamma(3, 2.1), 1E-4);
-    }
-
-    /**
-     * Test of upperIncompleteGamma method, of class Gamma.
-     */
-    @Test
-    public void testUpperIncompleteGamma() {
-        System.out.println("incompleteGamma");
-        assertEquals(0.2193, Gamma.regularizedUpperIncompleteGamma(2.1, 3), 1E-4);
-        assertEquals(0.6496, Gamma.regularizedUpperIncompleteGamma(3, 2.1), 1E-4);
+        double pLow = Beta.regularizedIncompleteBetaFunction(1, 1, -0.000000000000001);
+        assertEquals(0.0, pLow, 0.0);
     }
 }


### PR DESCRIPTION
My team discovered https://github.com/haifengl/smile/issues/477#issue-515181409 with our randomized testing.

This PR includes tests that demonstrate the bug (both with the original data in RidgeRegression and the computation in Beta#regularizedIncompleteBetaFunction), a fix for the floating point comparison logic, and simplifies the conditional branching in Beta#regularizedIncompleteBetaFunction.