### PR TITLE
remove unused import which might cause compilation error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ hs_err_pid*
 .cache-tests
 .classpath
 */.gitignore
+/bin/

--- a/math/src/main/java/smile/stat/distribution/PoissonDistribution.java
+++ b/math/src/main/java/smile/stat/distribution/PoissonDistribution.java
@@ -17,7 +17,7 @@
 
 package smile.stat.distribution;
 
-import javafx.geometry.Pos;
+//import javafx.geometry.Pos;
 import smile.math.special.Gamma;
 import smile.math.MathEx;
 


### PR DESCRIPTION
since JDK11, javafx is no longer default shipped with jdk, so this unused import might cause issue when using latest version of JDK 