### PR TITLE
tune the refactored unwindPathSum

### DIFF
--- a/core/src/main/java/smile/regression/RegressionTree.java
+++ b/core/src/main/java/smile/regression/RegressionTree.java
@@ -493,17 +493,18 @@ public class RegressionTree extends CART implements Regression<Tuple>, DataFrame
             double n = w[l];
             if (po != 0) {
                 for (int j = l - 1; j >= 0; j--) {
-                    double t =  n / ((j+1) * po);
+                    double t =  (n * (l + 1)) / ((j+1) * po);
                     sum += t;
-                    n = w[j] - t * pz * (l - j);
-                }
+                    n = w[j] - t * pz * ((l - j) / (l + 1));
+                }                
+                return sum;
             } else {
                 for (int j = l - 1; j >= 0; j--) {
                     sum += w[j] / (pz * (l - j));
                 }
+                return sum * (l + 1);
             }
-
-            return sum * (l + 1);
+            
         }
     }
 }

--- a/core/src/test/java/smile/regression/GradientTreeBoostTest.java
+++ b/core/src/test/java/smile/regression/GradientTreeBoostTest.java
@@ -159,7 +159,7 @@ public class GradientTreeBoostTest {
     @Test
     public void testShap() {
         MathEx.setSeed(19650218); // to get repeatable results.
-        GradientTreeBoost model = GradientTreeBoost.fit(BostonHousing.formula, BostonHousing.data, Loss.ls(), 100, 6, 100, 5, 0.05, 0.7);
+        GradientTreeBoost model = GradientTreeBoost.fit(BostonHousing.formula, BostonHousing.data, Loss.ls(), 100, 3, 10, 5, 0.01, 1);
         double[] importance = model.importance();
         double[] shap = model.shap(BostonHousing.data.stream().parallel());
 
@@ -177,13 +177,13 @@ public class GradientTreeBoostTest {
             System.out.format("%-15s %.4f%n", fields[i], shap[i]);
         }
 
-        assertTrue(fields[shap.length - 1].equals("RM"));
-        //assertEquals(2.3696, shap[shap.length - 1], 1E-4);
-        assertTrue(fields[shap.length - 2].equals("PTRATIO"));
-        //assertEquals(1.4839, shap[shap.length - 2], 1E-4);
-        assertTrue(fields[shap.length - 3].equals("LSTAT"));
-        //assertEquals(0.1999, shap[shap.length - 3], 1E-4);
-        assertTrue(fields[shap.length - 4].equals("TAX"));
-        //assertEquals(0.1617, shap[shap.length - 4], 1E-4);
+        assertTrue(fields[shap.length - 1].equals("LSTAT"));
+        assertEquals(2.6433, shap[shap.length - 1], 1E-4);
+        assertTrue(fields[shap.length - 2].equals("RM"));
+        assertEquals(1.6692, shap[shap.length - 2], 1E-4);
+        assertTrue(fields[shap.length - 3].equals("NOX"));
+        assertEquals(0.2179, shap[shap.length - 3], 1E-4);
+        assertTrue(fields[shap.length - 4].equals("CRIM"));
+        assertEquals(0.1754, shap[shap.length - 4], 1E-4);
     }
 }


### PR DESCRIPTION
seems the parameter for `GradientTreeBoost` affect the shap value for this dataset but also a minor calculation issue found in `unwindPathSum` function.

another minor concern is the default for-loop in `TreeSHAP` iterating over all trees might cause a lot double/int array to create along the path if we have thousands of trees (could easily double memory footprint from 200MB to 400MB for some big dataset like `ailerons` with 5000 trees). Since the tree calculation is sequentially/independently one by one, some kind of memory optimization might be a choice there? for example, we could re-use (reset after use) same pre-allocated array among trees (so the array created on the fly would be like `O(1)` instead of `O(# of trees)`), but that require sub-indexing support in `extendPath`,`unwindPath`,`unwindPathSum` and `recurse`. 

just my 2 cents. Thanks