### PR TITLE
Switch distance to distanceSq

### DIFF
--- a/core/src/main/java/smile/manifold/NearestNeighborGraph.java
+++ b/core/src/main/java/smile/manifold/NearestNeighborGraph.java
@@ -93,7 +93,7 @@ class NearestNeighborGraph {
                 int v1 = i;
                 for (int j = 0; j < neighbors.length; j++) {
                     int v2 = neighbors[j].index;
-                    double weight = neighbors[j].distance;
+                    double weight = Math.sqrt(neighbors[j].distanceSq);
                     graph.setWeight(v1, v2, weight);
                     consumer.accept(v1, v2, weight, j);
                 }
@@ -101,7 +101,7 @@ class NearestNeighborGraph {
         } else {
             for (int i = 0; i < n; i++) {
                 for (Neighbor<T, T> neighbor : knn.knn(data[i], k)) {
-                    graph.setWeight(i, neighbor.index, neighbor.distance);
+                    graph.setWeight(i, neighbor.index, Math.sqrt(neighbor.distanceSq));
                 }
             }
         }

--- a/core/src/main/java/smile/neighbor/KDTree.java
+++ b/core/src/main/java/smile/neighbor/KDTree.java
@@ -245,10 +245,10 @@ public class KDTree <E> implements NearestNeighborSearch<double[], E>, KNNSearch
             for (int idx = node.index; idx < node.index + node.count; idx++) {
                 int i = index[idx];
                 if (q != keys[i]) {
-                    double distance = MathEx.distance(q, keys[i]);
-                    if (distance < neighbor.distance) {
+                    double distanceSq = MathEx.squaredDistance(q, keys[i]);
+                    if (distanceSq < neighbor.distanceSq) {
                         neighbor.index = i;
-                        neighbor.distance = distance;
+                        neighbor.distanceSq = distanceSq;
                     }
                 }
             }
@@ -266,7 +266,7 @@ public class KDTree <E> implements NearestNeighborSearch<double[], E>, KNNSearch
             search(q, nearer, neighbor);
 
             // now look in further half
-            if (neighbor.distance >= diff) {
+            if (neighbor.distanceSq >= diff * diff) {
                 search(q, further, neighbor);
             }
         }
@@ -287,10 +287,10 @@ public class KDTree <E> implements NearestNeighborSearch<double[], E>, KNNSearch
             for (int idx = node.index; idx < node.index + node.count; idx++) {
                 int i = index[idx];
                 if (q != keys[i]) {
-                    double distance = MathEx.distance(q, keys[i]);
+                    double distanceSq = MathEx.squaredDistance(q, keys[i]);
                     NeighborBuilder<double[], E> datum = heap.peek();
-                    if (distance < datum.distance) {
-                        datum.distance = distance;
+                    if (distanceSq < datum.distanceSq) {
+                        datum.distanceSq = distanceSq;
                         datum.index = i;
                         heap.heapify();
                     }
@@ -310,7 +310,7 @@ public class KDTree <E> implements NearestNeighborSearch<double[], E>, KNNSearch
             search(q, nearer, heap);
 
             // now look in further half
-            if (heap.peek().distance >= diff) {
+            if (heap.peek().distanceSq >= diff * diff) {
                 search(q, further, heap);
             }
         }
@@ -331,9 +331,9 @@ public class KDTree <E> implements NearestNeighborSearch<double[], E>, KNNSearch
             for (int idx = node.index; idx < node.index + node.count; idx++) {
                 int i = index[idx];
                 if (q != keys[i]) {
-                    double distance = MathEx.distance(q, keys[i]);
-                    if (distance <= radius) {
-                        neighbors.add(new Neighbor<>(keys[i], data[i], i, distance));
+                    double distanceSq = MathEx.squaredDistance(q, keys[i]);
+                    if (distanceSq <= radius * radius) {
+                        neighbors.add(new Neighbor<>(keys[i], data[i], i, distanceSq));
                     }
                 }
             }

--- a/core/src/main/java/smile/neighbor/LinearSearch.java
+++ b/core/src/main/java/smile/neighbor/LinearSearch.java
@@ -80,15 +80,16 @@ public class LinearSearch<T> implements NearestNeighborSearch<T,T>, KNNSearch<T,
         double[] dist = Arrays.stream(data).parallel().mapToDouble(x -> distance.d(q, x)).toArray();
 
         int index = -1;
-        double nearest = Double.MAX_VALUE;
+        double nearestSq = Double.MAX_VALUE;
         for (int i = 0; i < dist.length; i++) {
-            if (dist[i] < nearest && q != data[i]) {
+            double dSq = dist[i] * dist[i];
+            if (dSq < nearestSq && q != data[i]) {
                 index = i;
-                nearest = dist[i];
+                nearestSq = dSq;
             }
         }
 
-        return Neighbor.of(data[index], index, nearest);
+        return Neighbor.of(data[index], index, nearestSq);
     }
 
     @Override
@@ -110,8 +111,9 @@ public class LinearSearch<T> implements NearestNeighborSearch<T,T>, KNNSearch<T,
 
         for (int i = 0; i < dist.length; i++) {
             NeighborBuilder<T,T> datum = heap.peek();
-            if (dist[i] < datum.distance && q != data[i]) {
-                datum.distance = dist[i];
+            double dSq = dist[i] * dist[i];
+            if (dSq < datum.distanceSq && q != data[i]) {
+                datum.distanceSq = dSq;
                 datum.index = i;
                 datum.key = data[i];
                 datum.value = data[i];
@@ -132,7 +134,7 @@ public class LinearSearch<T> implements NearestNeighborSearch<T,T>, KNNSearch<T,
         double[] dist = Arrays.stream(data).parallel().mapToDouble(x -> distance.d(q, x)).toArray();
         for (int i = 0; i < data.length; i++) {
             if (dist[i] <= radius && q != data[i]) {
-                neighbors.add(Neighbor.of(data[i], i, dist[i]));
+                neighbors.add(Neighbor.of(data[i], i, dist[i] * dist[i]));
             }
         }
     }

--- a/core/src/main/java/smile/neighbor/Neighbor.java
+++ b/core/src/main/java/smile/neighbor/Neighbor.java
@@ -46,9 +46,9 @@ public class Neighbor<K, V> implements Comparable<Neighbor<K,V>> {
      */
     public final int index;
     /**
-     * The distance between the query and the neighbor.
+     * The squared distance between the query and the neighbor.
      */
-    public final double distance;
+    public final double distanceSq;
 
     /**
      * Constructor.
@@ -57,16 +57,16 @@ public class Neighbor<K, V> implements Comparable<Neighbor<K,V>> {
      * @param index the index of neighbor object in the dataset.
      * @param distance the distance between the query and the neighbor.
      */
-    public Neighbor(K key, V object, int index, double distance) {
+    public Neighbor(K key, V object, int index, double distanceSq) {
         this.key = key;
         this.value = object;
         this.index = index;
-        this.distance = distance;
+        this.distanceSq = distanceSq;
     }
 
     @Override
     public int compareTo(Neighbor<K,V> o) {
-        int d = Double.compare(distance, o.distance);
+        int d = Double.compare(distanceSq, o.distanceSq);
         // Sometime, the dataset contains duplicate samples.
         // If the distances are same, we sort by the sample index.
         return d == 0 ? Integer.compare(index, o.index) : d;
@@ -74,11 +74,11 @@ public class Neighbor<K, V> implements Comparable<Neighbor<K,V>> {
 
     @Override
     public String toString() {
-        return String.format("%s(%d):%s", key, index, Strings.decimal(distance));
+        return String.format("%s(%d):%s", key, index, Strings.decimal(Math.sqrt(distanceSq)));
     }
 
     /** Creates a neighbor object, of which key and object are the same. */
-    public static <T> Neighbor<T, T> of(T key, int index, double distance) {
-        return new Neighbor<>(key, key, index, distance);
+    public static <T> Neighbor<T, T> of(T key, int index, double distanceSq) {
+        return new Neighbor<>(key, key, index, distanceSq);
     }
 }

--- a/core/src/main/java/smile/neighbor/NeighborBuilder.java
+++ b/core/src/main/java/smile/neighbor/NeighborBuilder.java
@@ -39,16 +39,16 @@ class NeighborBuilder<K, V> implements Comparable<NeighborBuilder<K,V>> {
      */
     int index;
     /**
-     * The distance between the query and the neighbor.
+     * The squared distance between the query and the neighbor.
      */
-    double distance;
+    double distanceSq;
 
     /**
      * Constructor.
      */
     public NeighborBuilder() {
         this.index = -1;
-        this.distance = Double.MAX_VALUE;
+        this.distanceSq = Double.MAX_VALUE;
     }
 
     /**
@@ -56,23 +56,23 @@ class NeighborBuilder<K, V> implements Comparable<NeighborBuilder<K,V>> {
      * @param key the key of neighbor.
      * @param value the value of neighbor.
      * @param index the index of neighbor object in the dataset.
-     * @param distance the distance between the query and the neighbor.
+     * @param distanceSq the squared distance between the query and the neighbor.
      */
-    public NeighborBuilder(K key, V value, int index, double distance) {
+    public NeighborBuilder(K key, V value, int index, double distanceSq) {
         this.key = key;
         this.value = value;
         this.index = index;
-        this.distance = distance;
+        this.distanceSq = distanceSq;
     }
 
     /** Creates a neighbor object. */
     public Neighbor<K, V> toNeighbor() {
-        return new Neighbor<>(key, value, index, distance);
+        return new Neighbor<>(key, value, index, distanceSq);
     }
 
     @Override
     public int compareTo(NeighborBuilder<K,V> o) {
-        int d = Double.compare(distance, o.distance);
+        int d = Double.compare(distanceSq, o.distanceSq);
         // Sometime, the dataset contains duplicate samples.
         // If the distances are same, we sort by the sample index.
         return d == 0 ? index - o.index : d;

--- a/core/src/test/java/smile/neighbor/CoverTreeTest.java
+++ b/core/src/test/java/smile/neighbor/CoverTreeTest.java
@@ -76,7 +76,7 @@ public class CoverTreeTest {
             Neighbor n2 = naive.nearest(data[i]);
             assertEquals(n1.index, n2.index);
             assertEquals(n1.value, n2.value);
-            assertEquals(n1.distance, n2.distance, 1E-7);
+            assertEquals(n1.distanceSq, n2.distanceSq, 1E-7);
         }
     }
 
@@ -95,7 +95,7 @@ public class CoverTreeTest {
             for (int j = 0; j < n1.length; j++) {
                 assertEquals(n1[j].index, n2[j].index);
                 assertEquals(n1[j].value, n2[j].value);
-                assertEquals(n1[j].distance, n2[j].distance, 1E-7);
+                assertEquals(n1[j].distanceSq, n2[j].distanceSq, 1E-7);
             }
         }
     }
@@ -116,7 +116,7 @@ public class CoverTreeTest {
         assertEquals(1, n1.length);
         assertEquals(0, n1[0].index);
         assertEquals(data[0], n1[0].value);
-        assertEquals(d.d(data[0], data[1]), n1[0].distance, 1E-7);
+        assertEquals(d.d(data[0], data[1]), Math.sqrt(n1[0].distanceSq), 1E-7);
     }
 
     @Test
@@ -138,7 +138,7 @@ public class CoverTreeTest {
             for (int j = 0; j < n1.size(); j++) {
                 assertEquals(n1.get(j).index, n2.get(j).index);
                 assertEquals(n1.get(j).value, n2.get(j).value);
-                assertEquals(n1.get(j).distance, n2.get(j).distance, 1E-7);
+                assertEquals(n1.get(j).distanceSq, n2.get(j).distanceSq, 1E-7);
             }
             n1.clear();
             n2.clear();

--- a/core/src/test/java/smile/neighbor/KDTreeTest.java
+++ b/core/src/test/java/smile/neighbor/KDTreeTest.java
@@ -72,7 +72,7 @@ public class KDTreeTest {
             Neighbor<double[], double[]> n2 = naive.nearest(data[i]);
             assertEquals(n1.index, n2.index);
             assertEquals(n1.value, n2.value);
-            assertEquals(n1.distance, n2.distance, 1E-7);
+            assertEquals(n1.distanceSq, n2.distanceSq, 1E-7);
         }
     }
 
@@ -90,7 +90,7 @@ public class KDTreeTest {
             for (int j = 0; j < n1.length; j++) {
                 assertEquals(n1[j].index, n2[j].index);
                 assertEquals(n1[j].value, n2[j].value);
-                assertEquals(n1[j].distance, n2[j].distance, 1E-7);
+                assertEquals(n1[j].distanceSq, n2[j].distanceSq, 1E-7);
             }
         }
     }
@@ -114,7 +114,7 @@ public class KDTreeTest {
             for (int j = 0; j < n1.size(); j++) {
                 assertEquals(n1.get(j).index, n2.get(j).index);
                 assertEquals(n1.get(j).value, n2.get(j).value);
-                assertEquals(n1.get(j).distance, n2.get(j).distance, 1E-7);
+                assertEquals(n1.get(j).distanceSq, n2.get(j).distanceSq, 1E-7);
             }
             n1.clear();
             n2.clear();
@@ -130,7 +130,7 @@ public class KDTreeTest {
             for (int j = 0; j < n1.size(); j++) {
                 assertEquals(n1.get(j).index, n2.get(j).index);
                 assertEquals(n1.get(j).value, n2.get(j).value);
-                assertEquals(n1.get(j).distance, n2.get(j).distance, 1E-7);
+                assertEquals(n1.get(j).distanceSq, n2.get(j).distanceSq, 1E-7);
             }
             n1.clear();
             n2.clear();

--- a/core/src/test/java/smile/neighbor/LSHTest.java
+++ b/core/src/test/java/smile/neighbor/LSHTest.java
@@ -79,7 +79,7 @@ public class LSHTest {
                 if (neighbor.index == truth.index) {
                     recall++;
                 } else {
-                    error += Math.abs(neighbor.distance - truth.distance) / truth.distance;
+                    error += Math.abs(Math.sqrt(neighbor.distanceSq) - Math.sqrt(truth.distanceSq)) / Math.sqrt(truth.distanceSq);
                 }
             }
         }

--- a/core/src/test/java/smile/neighbor/LinearSearchTest.java
+++ b/core/src/test/java/smile/neighbor/LinearSearchTest.java
@@ -80,7 +80,7 @@ public class LinearSearchTest {
         assertEquals(1, n1.length);
         assertEquals(0, n1[0].index);
         assertEquals(data[0], n1[0].value);
-        assertEquals(d.d(data[0], data[1]), n1[0].distance, 1E-7);
+        assertEquals(d.d(data[0], data[1]), Math.sqrt(n1[0].distanceSq), 1E-7);
     }
 
     @Test(expected = Test.None.class)

--- a/core/src/test/java/smile/neighbor/MPLSHTest.java
+++ b/core/src/test/java/smile/neighbor/MPLSHTest.java
@@ -91,7 +91,7 @@ public class MPLSHTest {
                 if (neighbor.index == truth.index) {
                     recall++;
                 } else {
-                    error += Math.abs(neighbor.distance - truth.distance) / truth.distance;
+                    error += Math.abs(Math.sqrt(neighbor.distanceSq) - Math.sqrt(truth.distanceSq)) / Math.sqrt(truth.distanceSq);
                 }
             }
         }

--- a/demo/src/main/java/smile/demo/neighbor/KNNDemo.java
+++ b/demo/src/main/java/smile/demo/neighbor/KNNDemo.java
@@ -158,7 +158,7 @@ public class KNNDemo extends JPanel implements Runnable, ActionListener {
         for (int i = 0; i < 1000; i++) {
             answers.add(naive.knn(data[perm[i]], knn));
             for (int j = 0; j < answers.get(i).length; j++) {
-                radius += answers.get(i)[j].distance;
+                radius += Math.sqrt(answers.get(i)[j].distanceSq);
             }
         }
         int naiveSearch = (int) (System.currentTimeMillis() - time);

--- a/demo/src/main/java/smile/demo/neighbor/NearestNeighborDemo.java
+++ b/demo/src/main/java/smile/demo/neighbor/NearestNeighborDemo.java
@@ -146,7 +146,7 @@ public class NearestNeighborDemo extends JPanel implements Runnable, ActionListe
         for (int i = 0; i < 100; i++) {
             Neighbor<double[], double[]> neighbor = naive.nearest(data[perm[i]]);
             answer[i] = neighbor.index;
-            radius += neighbor.distance;
+            radius += Math.sqrt(neighbor.distanceSq);
         }
         int naiveSearch = (int) (System.currentTimeMillis() - time);
         radius /= 100;


### PR DESCRIPTION
EXPERIMENTAL PULL REQUEST ONLY -- do not merge.

Replaces `distance` with `distanceSq` (see #491).

Contains just enough changes to have `sbt 'testOnly **.KDTreeTest'` pass all unit tests.

Benchmark code:

```java
    public static void main(String[] args) {
        int N = 40000;
        int size = 100;
        int numTests = 100_000;
        
        Random rand = new Random(1);
        
        double[][] coords = new double[N][3];
        Integer[] vals = new Integer[N];
        for (int i = 0; i < N; i++) {
            coords[i][0] = rand.nextDouble() * size - size/2;
            coords[i][1] = rand.nextDouble() * size - size/2;
            coords[i][2] = rand.nextDouble() * size - size/2;
            vals[i] = i;
        }
        KDTree<Integer> kdt = new KDTree<>(coords, vals);
        
        long startTime = System.nanoTime();
        double[] q = new double[3];
        for (int i = 0; i < numTests; i++) {
            q[0] = rand.nextDouble() * size - size/2;
            q[1] = rand.nextDouble() * size - size/2;
            q[2] = rand.nextDouble() * size - size/2;
            Neighbor<double[], Integer> nearest = kdt.nearest(q);
            // System.out.println(nearest.index);
        }
        System.out.println("Took " + (System.nanoTime() - startTime) * 1.0e-9 + " sec");
    }
```

Uncomment the `println` command to verify that the same exact nearest neighbors are returned for the original (git latest) version of SMILE and this modified version.

Benchmark: 

* Original: 13.74 sec
* This modified version: 0.11 sec
* Speedup: 124x