### PR TITLE
[WIP] fix incompatibility between one versus rest and DataFrameClassifiers

### DIFF
--- a/core/src/main/java/smile/classification/DataFrameClassifier.java
+++ b/core/src/main/java/smile/classification/DataFrameClassifier.java
@@ -27,7 +27,7 @@ import smile.data.type.StructType;
  *
  * @author Haifeng Li
  */
-public interface DataFrameClassifier {
+public interface DataFrameClassifier extends SoftClassifier<Tuple> {
 
     /**
      * Predicts the class label of an instance.

--- a/core/src/main/java/smile/validation/CrossValidation.java
+++ b/core/src/main/java/smile/validation/CrossValidation.java
@@ -20,7 +20,9 @@ package smile.validation;
 import java.util.function.BiFunction;
 import smile.classification.Classifier;
 import smile.classification.DataFrameClassifier;
+import smile.classification.SoftClassifier;
 import smile.data.DataFrame;
+import smile.data.Tuple;
 import smile.data.formula.Formula;
 import smile.math.MathEx;
 import smile.regression.DataFrameRegression;
@@ -137,11 +139,11 @@ public class CrossValidation {
      * Runs cross validation tests.
      * @return the predictions.
      */
-    public int[] classification(Formula formula, DataFrame data, BiFunction<Formula, DataFrame, DataFrameClassifier> trainer) {
+    public int[] classification(Formula formula, DataFrame data, BiFunction<Formula, DataFrame, SoftClassifier<Tuple>> trainer) {
         int[] prediction = new int[data.size()];
 
         for (int i = 0; i < k; i++) {
-            DataFrameClassifier model = trainer.apply(formula, data.of(train[i]));
+            SoftClassifier<Tuple> model = trainer.apply(formula, data.of(train[i]));
             for (int j : test[i]) {
                 prediction[j] = model.predict(data.get(j));
             }
@@ -202,7 +204,7 @@ public class CrossValidation {
      * Runs cross validation tests.
      * @return the predictions.
      */
-    public static int[] classification(int k, Formula formula, DataFrame data, BiFunction<Formula, DataFrame, DataFrameClassifier> trainer) {
+    public static int[] classification(int k, Formula formula, DataFrame data, BiFunction<Formula, DataFrame, SoftClassifier<Tuple>> trainer) {
         CrossValidation cv = new CrossValidation(data.size(), k);
         return cv.classification(formula, data, trainer);
     }

--- a/scala/src/main/scala/smile/classification/package.scala
+++ b/scala/src/main/scala/smile/classification/package.scala
@@ -18,10 +18,11 @@
 package smile
 
 import java.util.stream.LongStream
+
 import smile.base.cart.SplitRule
 import smile.base.mlp.LayerBuilder
 import smile.base.rbf.RBF
-import smile.data.DataFrame
+import smile.data.{DataFrame, Tuple}
 import smile.data.formula.Formula
 import smile.math.MathEx
 import smile.math.TimeFunction
@@ -979,6 +980,10 @@ package object classification {
     */
   def ovr[T <: AnyRef](x: Array[T], y: Array[Int])(trainer: (Array[T], Array[Int]) => Classifier[T]): OneVersusRest[T] = time("One vs. Rest") {
     OneVersusRest.fit(x, y, trainer)
+  }
+
+  def ovr(formula: Formula, data: DataFrame)(trainer: (Formula, DataFrame) => SoftClassifier[Tuple]): OneVersusRest[Tuple] = time("One vs. Rest") {
+    OneVersusRest.fit(formula, data, trainer)
   }
 
   /** Hacking scaladoc [[https://github.com/scala/bug/issues/8124 issue-8124]].

--- a/scala/src/main/scala/smile/classification/package.scala
+++ b/scala/src/main/scala/smile/classification/package.scala
@@ -982,7 +982,7 @@ package object classification {
     OneVersusRest.fit(x, y, trainer)
   }
 
-  def ovr(formula: Formula, data: DataFrame)(trainer: (Formula, DataFrame) => SoftClassifier[Tuple]): OneVersusRest[Tuple] = time("One vs. Rest") {
+  def ovr(formula: Formula, data: DataFrame)(trainer: (Formula, DataFrame) => DataFrameClassifier): OneVersusRest[Tuple] = time("One vs. Rest") {
     OneVersusRest.fit(formula, data, trainer)
   }
 

--- a/scala/src/main/scala/smile/validation/package.scala
+++ b/scala/src/main/scala/smile/validation/package.scala
@@ -455,7 +455,7 @@ package object validation {
       * @param trainer  a code block to return a classifier trained on the given data.
       * @return measure results.
       */
-    def classification(k: Int, formula: Formula, data: DataFrame, measures: ClassificationMeasure*)(trainer: (Formula, DataFrame) => DataFrameClassifier): Array[Double] = {
+    def classification(k: Int, formula: Formula, data: DataFrame, measures: ClassificationMeasure*)(trainer: (Formula, DataFrame) => SoftClassifier[Tuple]): Array[Double] = {
       val prediction = CrossValidation.classification(k, formula, data, trainer)
       val y = formula.y(data).toIntArray
       println("Confusion Matrix: %s" format ConfusionMatrix.of(y, prediction))


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x ] Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
- [ x] Check the commit's or even all commits' message styles matches our requested structure.
- [x ] Check your code additions will fail neither code linting checks nor unit test.

### Description
Please describe your pull request.

Hi, I developed a fix to make OneVersusRest Compatible with SoftClassifier. This is related to [this issue](https://github.com/haifengl/smile/issues/607)
To do so, I defined a new fit method for OneVersusRest.
I also modified the predict so that it uses platt scaling only for non SoftClassifiers.
It is now possible to do that:
```
val data = read.csv("data/usps/zip.train", delimiter = ' ' , header = false)
val formula = "V1" ~
val model = ovr(formula, data) { (formula, data) => RandomForest.fit(formula, data) }
```
I also changed a tiny bit the CrossValidation to make it compatible with this:
```
cv.classification(10, formula, data) { case (formula, data) => ovr(formula, data) { (formula, data) => RandomForest.fit(formula, data) } }
```
I put it as WIP because I could add some tests and maybe some scaladoc.
I would love to have your feedback.

Thank you!
