### PR TITLE
Fix scala DataFrameOps partition

### DIFF
--- a/scala/src/main/scala/smile/data/DataFrame.scala
+++ b/scala/src/main/scala/smile/data/DataFrame.scala
@@ -68,7 +68,7 @@ case class DataFrameOps(data: DataFrame) {
     val l = new scala.collection.mutable.ArrayBuffer[Int]
     val r = new scala.collection.mutable.ArrayBuffer[Int]
     IntStream.range(0, data.size).forEach { i =>
-      if (p(data(i))) l :+ i else r :+ i
+      if (p(data(i))) l += i else r += i
     }
     (data.of(l.toArray: _*), data.of(r.toArray: _*))
   }


### PR DESCRIPTION
`l :+ i` returns a copy of the original collection with `i` appended, hence `l` and `r` are always empty
`l += i` appends `i` to the original collection, hence `l` and `r` will contain the required partitioning
