### PR TITLE
Coursier Bootstrapping #671

### DIFF
--- a/shell/src/universal/bin/jupyterlab.sh
+++ b/shell/src/universal/bin/jupyterlab.sh
@@ -53,7 +53,7 @@ install_almond() {
       chmod +x coursier
   fi
 
-  SCALA_VERSION=2.13.4 ALMOND_VERSION=0.11.2
+  SCALA_VERSION=2.13.5 ALMOND_VERSION=0.11.2
 
   ./coursier bootstrap \
       -r jitpack \

--- a/shell/src/universal/bin/jupyterlab.sh
+++ b/shell/src/universal/bin/jupyterlab.sh
@@ -53,7 +53,7 @@ install_almond() {
       chmod +x coursier
   fi
 
-  SCALA_VERSION=2.13.5 ALMOND_VERSION=0.11.2
+  SCALA_VERSION=2.13.4 ALMOND_VERSION=0.11.2
 
   ./coursier bootstrap \
       -r jitpack \
@@ -62,6 +62,7 @@ install_almond() {
       sh.almond:scala-kernel_$SCALA_VERSION:$ALMOND_VERSION \
       --sources \
       --default=true \
+      --main-class almond.ScalaKernel \
       -f -o almond-scala-2.13
 
   ./almond-scala-2.13 --install --force --id scala213 --display-name "Scala (2.13)" \

--- a/web/quickstart.html
+++ b/web/quickstart.html
@@ -415,7 +415,8 @@ smile&gt;
     <p>You can also use Smile in your favorite Notebook.
         We recommend JupyterLab and provide <code>jupyterlab.sh</code>
         to setup the conda environment of Jupyter Lab for Smile with
-        kernels for Scala, Kotlin and Clojure. When you run
+        kernels for Scala, Kotlin and Clojure. The script is located at
+        <code>./shell/src/universal/bin/jupyterlab.sh</code>. When you run
         <code>jupyterlab.sh</code> first time, it will set up the environment
         automatically. You can update the environment with the option
         <code>--update</code> later when needed. You may install BeakerX

--- a/web/quickstart.html
+++ b/web/quickstart.html
@@ -415,9 +415,8 @@ smile&gt;
     <p>You can also use Smile in your favorite Notebook.
         We recommend JupyterLab and provide <code>jupyterlab.sh</code>
         to setup the conda environment of Jupyter Lab for Smile with
-        kernels for Scala, Kotlin and Clojure. The script is located at
-        <code>./shell/src/universal/bin/jupyterlab.sh</code>. When you run
-        <code>jupyterlab.sh</code> first time, it will set up the environment
+        kernels for Scala, Kotlin and Clojure. When you run
+        <code>jupyterlab.sh</code> the first time, it will set up the environment
         automatically. You can update the environment with the option
         <code>--update</code> later when needed. You may install BeakerX
         with <code>--install-beakerx</code> for other JVM kernels.


### PR DESCRIPTION
Issue #671

- setting scala version back to 2.13.4
- setting `main-class`
- Updating github.io website to note location of script `took second to find` 

Kernel is installed and working

![Screen Shot 2021-06-10 at 1 35 57 AM](https://user-images.githubusercontent.com/1041016/121470505-509cf480-c98c-11eb-88c7-a3bd21c80961.png)
