### PR TITLE
Fix xh initialization in gradient computation

### DIFF
--- a/math/src/main/java/smile/math/DifferentiableMultivariateFunction.java
+++ b/math/src/main/java/smile/math/DifferentiableMultivariateFunction.java
@@ -40,7 +40,7 @@ public interface DifferentiableMultivariateFunction extends MultivariateFunction
         double fx = f(x);
 
         int n = x.length;
-        double[] xh = new double[n];
+        double[] xh = x.clone();
         for (int i = 0; i < n; i++) {
             double xi = x[i];
             double h = EPSILON * Math.abs(xi);


### PR DESCRIPTION
Commit 0a1bff0f6f301fc81ab123737d02823ab8e44da5 introduced a bug in the `AbstractDifferentiableMultivariateFunction` (now `DifferentiableMultivariateFunction`) gradient computation by incorrectly initializing `xh`.

This can be easilly tested in the scala console with:

```scala
val f: smile.math.DifferentiableMultivariateFunction = (x: Array[Double]) => x(0)*x(0) + x(1)*x(1) + x(2)*x(2)
val grad = Array(0.0, 0.0, 0.0)
f.g(Array(5,5,5), grad)
println(grad)
```

The version in `master` incorrectly computes the gradient as `Array(-9.99999996077471E8, -4.9999999303873545E8, 10.000000035527137)`, while now it's correctly computed as `Array(10.000000035527137, 10.000000035527137, 10.000000035527137)`