### PR TITLE
Avoid negative BM25 scores

### DIFF
--- a/nlp/src/main/java/smile/nlp/relevance/BM25.java
+++ b/nlp/src/main/java/smile/nlp/relevance/BM25.java
@@ -147,7 +147,7 @@ public class BM25 implements RelevanceRanker {
         }
         
         tf = tf / (kf + tf);
-        double idf = Math.log((N - n + 0.5) / (n + 0.5));
+        double idf = Math.log((N - n + 0.5) / (n + 0.5) + 1);
 
         return (tf + delta) * idf;
     }
@@ -163,7 +163,7 @@ public class BM25 implements RelevanceRanker {
         if (freq <= 0) return 0.0;
 
         double tf = (k1 + 1) * freq / (freq + k1);
-        double idf = Math.log((N - n + 0.5) / (n + 0.5));
+        double idf = Math.log((N - n + 0.5) / (n + 0.5) + 1);
 
         return (tf + delta) * idf;
     }
@@ -181,7 +181,7 @@ public class BM25 implements RelevanceRanker {
         if (freq <= 0) return 0.0;
 
         double tf = freq * (k1 + 1) / (freq + k1 * (1 - b + b * docSize / avgDocSize));
-        double idf = Math.log((N - n + 0.5) / (n + 0.5));
+        double idf = Math.log((N - n + 0.5) / (n + 0.5) + 1);
 
         return (tf + delta) * idf;
     }

--- a/nlp/src/test/java/smile/nlp/relevance/BM25Test.java
+++ b/nlp/src/test/java/smile/nlp/relevance/BM25Test.java
@@ -61,7 +61,7 @@ public class BM25Test {
         int N = 10000000;
         int n = 1000;
         BM25 instance = new BM25(2.0, 0.75, 0.0);
-        double expResult = 18.419481;
+        double expResult = 18.419681;
         double result = instance.score(freq, docSize, avgDocSize, N, n);
         assertEquals(expResult, result, 1E-6);
     }


### PR DESCRIPTION
### Description
This PR implements the suggestions of #682 by adjusting the IDF formula within the _BM25.java_ class at three places. Due to this change, the expected value of the corresponding unit test changed slightly and is hence adjusted as well.

Please tell me if something is wrong with this PR or if you do not see a need for this formula change. Thanks in advance!