### PR TITLE
fix test data path

### DIFF
--- a/base/src/main/java/smile/util/Paths.java
+++ b/base/src/main/java/smile/util/Paths.java
@@ -18,6 +18,7 @@
 package smile.util;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.stream.Stream;
@@ -29,7 +30,7 @@ import java.util.stream.Stream;
  */
 public interface Paths {
     /** Smile home directory. */
-    String home = System.getProperty("smile.home", "shell/src/universal/data");
+    String home = System.getProperty("smile.home", "shell/src/universal/");
 
     /**
      * Get the file path of a test sample dataset.
@@ -37,7 +38,7 @@ public interface Paths {
      * @return the file path to the test data.
      */
     static Path getTestData(String... path) {
-        return java.nio.file.Paths.get(home, path);
+        return java.nio.file.Paths.get(home + File.separator + "data", path);
     }
 
     /**

--- a/base/src/main/java/smile/util/Paths.java
+++ b/base/src/main/java/smile/util/Paths.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
  */
 public interface Paths {
     /** Smile home directory. */
-    String home = System.getProperty("smile.home", "shell/src/universal/");
+    String home = System.getProperty("smile.home", "shell/src/universal/data");
 
     /**
      * Get the file path of a test sample dataset.
@@ -37,7 +37,7 @@ public interface Paths {
      * @return the file path to the test data.
      */
     static Path getTestData(String... path) {
-        return java.nio.file.Paths.get(home + "/data", path);
+        return java.nio.file.Paths.get(home, path);
     }
 
     /**


### PR DESCRIPTION
It might help to add `/data` sub-folder in default system property value directly instead using string concatenation later. And plain string concatenation would encounter path seperator issue across platforms like Linux(using `/`) and Windows (using `\\` in Java).

For example, in Windows, with proposed change, developer could run the unit test with java option `-Dsmile.home=C:\smile\shell\src\universal\data` to override the default value