### PR TITLE
fix(FPTree): guard against negative index in freq when all counts are zero

### DIFF
--- a/core/src/main/java/smile/association/FPTree.java
+++ b/core/src/main/java/smile/association/FPTree.java
@@ -301,8 +301,8 @@ public class FPTree {
             numTransactions++;
             for (int i : itemset) f[i]++;
         });
-        while (f[--n] == 0);
-        return Arrays.copyOf(f, n+1);
+        while (n > 0 && f[--n] == 0);
+        return f[n] == 0 ? new int[0] : Arrays.copyOf(f, n + 1);
     }
     
     /**


### PR DESCRIPTION
Found a small bug in `FPTree.freq` while going through the codebase.

The `while (f[--n] == 0)` loop has no lower-bound guard. On an empty itemset stream all frequencies stay zero, so `n` keeps decrementing past 0 and hits `f[-1]`, throwing `ArrayIndexOutOfBoundsException`.

Happy to close if this is intentional, you know the codebase far better than I do.