### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/website/src/js/toc.js
+++ b/website/src/js/toc.js
@@ -111,11 +111,17 @@
             parent = parent.find('> li:last > ul:first');
         }
 
+        var $li = $('<li></li>');
         if (id === '') {
-            parent.append('<li>' + text + '</li>');
+            $li.text(text);
         } else {
-            parent.append('<li><a href="#' + id + '" class="scroll">' + text + '</a></li>');
+            var $a = $('<a></a>');
+            $a.attr('href', '#' + id);
+            $a.attr('class', 'scroll');
+            $a.text(text);
+            $li.append($a);
         }
+        parent.append($li);
     }
 
     $.fn.toc.defaults = {


### PR DESCRIPTION
Potential fix for [https://github.com/haifengl/smile/security/code-scanning/3](https://github.com/haifengl/smile/security/code-scanning/3)

General fix: stop building HTML with string concatenation when inserting values derived from DOM/content. Instead, create elements with jQuery, set attributes/text through APIs that do escaping, and append nodes.

Best fix here (without changing functionality): in `website/src/js/toc.js`, replace the `appendToTOC` implementation block that currently does:

- `parent.append('<li>' + text + '</li>');`
- `parent.append('<li><a href="#' + id + '" class="scroll">' + text + '</a></li>');`

with node construction:

- create `var $li = $('<li></li>');`
- for no `id`, set `$li.text(text)`;
- otherwise create `<a>`, set `href`/`class` via `.attr()`, set visible label via `.text(text)`, append link to li;
- append `$li` to `parent`.

This preserves behavior and removes HTML interpretation of `text`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
