### PR TITLE
Potential fix for code scanning alert no. 4: Unsafe jQuery plugin

### DIFF
--- a/website/src/js/toc.js
+++ b/website/src/js/toc.js
@@ -34,7 +34,7 @@
         }
 
         return this.each(function() {
-            $(opts.context + ' :header').not(opts.exclude).each(function() {
+            $($.find(opts.context + ' :header')).not(opts.exclude).each(function() {
                 var $this = $(this);
                 for (var i = 6; i >= 1; i--) {
                     if ($this.is('h' + i)) {


### PR DESCRIPTION
Potential fix for [https://github.com/haifengl/smile/security/code-scanning/4](https://github.com/haifengl/smile/security/code-scanning/4)

Use selector-only APIs instead of passing `opts.context` into `$()` as a raw string.  
Best fix here: replace `$(opts.context + ' :header').not(opts.exclude)` with a safe selector lookup that cannot be interpreted as HTML, e.g. `$( $.find(opts.context + ' :header') ).not(opts.exclude)`.

This keeps behavior (CSS selector matching in the current document) while removing the unsafe HTML-evaluating code path in `$()`.  
Only `website/src/js/toc.js` needs a change, at the `return this.each` block around line 37. No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
