### PR TITLE
Fix macro and weighted F-score to average per-class scores

### DIFF
--- a/core/src/main/java/smile/validation/metric/FScore.java
+++ b/core/src/main/java/smile/validation/metric/FScore.java
@@ -17,6 +17,7 @@
 package smile.validation.metric;
 
 import java.io.Serial;
+import smile.math.MathEx;
 
 /**
  * The F-score (or F-measure) considers both the precision and the recall of the test
@@ -100,7 +101,40 @@ public class FScore implements ClassificationMetric {
      * @return the metric.
      */
     public static double of(int[] truth, int[] prediction, double beta, Averaging strategy) {
+        if (truth.length != prediction.length) {
+            throw new IllegalArgumentException(String.format("The vector sizes don't match: %d != %d.", truth.length, prediction.length));
+        }
+
         double beta2 = beta * beta;
+
+        // Macro/Weighted F-score is the average of the per-class F-scores, not the
+        // F-score of the averaged precision and recall (those are not interchangeable).
+        if (strategy == Averaging.Macro || strategy == Averaging.Weighted) {
+            int numClasses = Math.max(MathEx.max(truth), MathEx.max(prediction)) + 1;
+            int[] tp = new int[numClasses];
+            int[] fp = new int[numClasses];
+            int[] size = new int[numClasses];
+            for (int i = 0; i < truth.length; i++) {
+                size[truth[i]]++;
+                if (truth[i] == prediction[i]) {
+                    tp[truth[i]]++;
+                } else {
+                    fp[prediction[i]]++;
+                }
+            }
+
+            double sum = 0.0;
+            for (int i = 0; i < numClasses; i++) {
+                double p = tp[i] + fp[i] == 0 ? 0.0 : (double) tp[i] / (tp[i] + fp[i]);
+                double r = size[i] == 0 ? 0.0 : (double) tp[i] / size[i];
+                double denom = beta2 * p + r;
+                double f = denom == 0.0 ? 0.0 : (1 + beta2) * p * r / denom;
+                sum += strategy == Averaging.Weighted ? f * size[i] : f;
+            }
+            return strategy == Averaging.Weighted ? sum / truth.length : sum / numClasses;
+        }
+
+        // Micro-averaging and binary reduce to a single (precision, recall) pair.
         double p = Precision.of(truth, prediction, strategy);
         double r = Recall.of(truth, prediction, strategy);
         return (1 + beta2) * (p * r) / (beta2 * p + r);

--- a/core/src/test/java/smile/validation/metric/FScoreTest.java
+++ b/core/src/test/java/smile/validation/metric/FScoreTest.java
@@ -96,9 +96,11 @@ public class FScoreTest {
                 0, 0, 0, 0, 0, 0, 0, 2, 3, 2, 2, 2, 3, 1, 3, 3, 3, 4, 5, 4, 4, 4, 4, 1, 5, 5
         };
         FScore instance = new FScore(1.0, Averaging.Macro);
-        double expResult = 0.8432;
+        // Mean of the per-class F1 scores (scikit-learn average='macro'). The
+        // previous value 0.8432 was F1 of the averaged precision and recall (#772).
+        double expResult = 0.840906;
         double result = instance.score(truth, prediction);
-        assertEquals(expResult, result, 1E-4);
+        assertEquals(expResult, result, 1E-5);
     }
 
     @Test
@@ -115,8 +117,40 @@ public class FScoreTest {
                 0, 0, 0, 0, 0, 0, 0, 2, 3, 2, 2, 2, 3, 1, 3, 3, 3, 4, 5, 4, 4, 4, 4, 1, 5, 5
         };
         FScore instance = new FScore(1.0, Averaging.Weighted);
-        double expResult = 0.8907;
+        // Support-weighted mean of the per-class F1 scores (scikit-learn
+        // average='weighted'). The previous value 0.8907 was F1 of the averaged
+        // precision and recall (#772).
+        double expResult = 0.889227;
         double result = instance.score(truth, prediction);
-        assertEquals(expResult, result, 1E-4);
+        assertEquals(expResult, result, 1E-5);
+    }
+
+    @Test
+    public void testMacroPerClass() {
+        System.out.println("Macro-FScore per-class");
+        // Equal supports (2/2/2); per-class F1 = [2/3, 4/5, 1]. Values verified
+        // against scikit-learn fbeta_score(average='macro').
+        int[] truth      = {0, 0, 1, 1, 2, 2};
+        int[] prediction = {0, 1, 1, 1, 2, 2};
+        assertEquals(0.822222, FScore.of(truth, prediction, 1.0, Averaging.Macro), 1E-6);
+        assertEquals(0.821549, FScore.of(truth, prediction, 2.0, Averaging.Macro), 1E-6);
+        assertEquals(0.849206, FScore.of(truth, prediction, 0.5, Averaging.Macro), 1E-6);
+        // With equal supports the weighted average matches the macro average.
+        assertEquals(0.822222, FScore.of(truth, prediction, 1.0, Averaging.Weighted), 1E-6);
+    }
+
+    @Test
+    public void testWeightedVsMacro() {
+        System.out.println("Weighted vs Macro FScore");
+        // Unequal supports (3/2/1) so weighted and macro differ. Values verified
+        // against scikit-learn fbeta_score(average='macro'/'weighted'/'micro').
+        int[] truth      = {0, 0, 0, 1, 1, 2};
+        int[] prediction = {0, 0, 1, 1, 2, 2};
+        assertEquals(0.655556, FScore.of(truth, prediction, 1.0, Averaging.Macro),    1E-6);
+        assertEquals(0.677778, FScore.of(truth, prediction, 1.0, Averaging.Weighted), 1E-6);
+        assertEquals(0.682540, FScore.of(truth, prediction, 2.0, Averaging.Macro),    1E-6);
+        assertEquals(0.662698, FScore.of(truth, prediction, 2.0, Averaging.Weighted), 1E-6);
+        // Micro F-score is unaffected (micro precision == micro recall == accuracy).
+        assertEquals(0.666667, FScore.of(truth, prediction, 1.0, Averaging.Micro),    1E-6);
     }
 }


### PR DESCRIPTION
For multi-class inputs, `FScore.of` with `Averaging.Macro`/`Weighted` returns Fβ of the *averaged* precision and recall instead of the mean of the *per-class* Fβ:

```java
double p = Precision.of(truth, prediction, strategy); // mean of the per-class precision
double r = Recall.of(truth, prediction, strategy);    // mean of the per-class recall
return (1 + beta2) * (p * r) / (beta2 * p + r);        // Fβ of two averages
```

Fβ is not linear in precision/recall, so `Fβ(mean P, mean R)` is not the macro/weighted F-score. The macro precision and macro recall themselves are already correct; only their combination into the F-score is off. The multi-class averaging support was added for #772.

Example — truth `{0,0,1,1,2,2}`, prediction `{0,1,1,1,2,2}` — against scikit-learn `fbeta_score`:

| metric | smile | scikit-learn |
|---|---|---|
| macro precision | 0.888889 | 0.888889 |
| macro recall | 0.833333 | 0.833333 |
| macro F1 | 0.860215 | 0.822222 |
| macro F2 | 0.843882 | 0.821549 |
| macro F0.5 | 0.877193 | 0.849206 |

Weighted is wrong the same way once supports are unequal: for truth `{0,0,0,1,1,2}`, prediction `{0,0,1,1,2,2}`, weighted F1 is 0.705882 vs 0.677778.

Fix: for Macro/Weighted, compute the per-class Fβ from the per-class counts and average them (unweighted for Macro, support-weighted for Weighted), matching `fbeta_score` including its `zero_division=0` for empty classes. Micro and binary are untouched (micro precision == micro recall; binary is a single class).

The two existing macro/weighted assertions pinned the old values and were updated; the new tests check the small examples above against scikit-learn. Ran `sbt "core / testOnly smile.validation.*"` (167 tests, green).

The torch-backed `deep.metric.F1Score` combines its precision and recall the same way; happy to address it in a follow-up.
