### PR TITLE
Fix macro/weighted F1 and two sibling averaging bugs in deep.metric

### DIFF
--- a/deep/src/main/java/smile/deep/metric/Averaging.java
+++ b/deep/src/main/java/smile/deep/metric/Averaging.java
@@ -16,6 +16,8 @@
  */
 package smile.deep.metric;
 
+import smile.deep.tensor.Tensor;
+
 /**
  * The averaging strategy to aggregate binary performance metrics across
  * multi-classes.
@@ -43,5 +45,18 @@ public enum Averaging {
      * Weighted macro for imbalanced classes. Note that weighted recall is
      * equal to accuracy.
      */
-    Weighted
+    Weighted;
+
+    /**
+     * Returns the support-weighted average of per-class scores. Shared by the
+     * metrics so that they all reduce the {@link #Weighted} strategy the same
+     * way, including the empty-state case right after {@code reset()}.
+     * @param score the score of each class.
+     * @param size the number of samples of each class.
+     * @return the weighted average, or 0 if there is no sample.
+     */
+    static double weighted(Tensor score, Tensor size) {
+        double n = size.sum().doubleValue();
+        return n == 0.0 ? 0.0 : score.mul(size).sum().doubleValue() / n;
+    }
 }

--- a/deep/src/main/java/smile/deep/metric/F1Score.java
+++ b/deep/src/main/java/smile/deep/metric/F1Score.java
@@ -26,6 +26,9 @@ import smile.deep.tensor.Tensor;
  * </pre>
  * It reaches its best value at 1 (perfect precision and recall) and
  * its worst value at 0.
+ * <p>
+ * For multi-class problems, the macro and weighted F1 are the (weighted)
+ * average of the per-class F1 scores.
  *
  * @author Haifeng Li
  */
@@ -84,6 +87,22 @@ public class F1Score implements Metric {
 
     @Override
     public double compute() {
+        if (strategy == Averaging.Macro || strategy == Averaging.Weighted) {
+            if (precision.tp == null) return 0.0;
+            // The F-score is not linear in precision and recall, so the macro and
+            // weighted F1 are the average of the per-class F1 scores, not the F1
+            // of the averaged precision and recall.
+            Tensor p = precision.score();
+            Tensor r = recall.score();
+            Tensor denom = p.add(r);
+            Tensor ones = denom.newOnes(denom.shape());
+            Tensor f1 = p.mul(r).mul(2.0).div(Tensor.where(denom.gt(0), denom, ones));
+            return strategy == Averaging.Macro ? f1.mean().doubleValue()
+                                               : Averaging.weighted(f1, recall.size);
+        }
+
+        // Binary classification and micro-averaging reduce to a single
+        // precision/recall pair, whose harmonic mean is the F1 score.
         double p = precision.compute();
         double r = recall.compute();
         double denom = p + r;

--- a/deep/src/main/java/smile/deep/metric/Precision.java
+++ b/deep/src/main/java/smile/deep/metric/Precision.java
@@ -115,20 +115,28 @@ public class Precision implements Metric {
         this.size.add_(size);
     }
 
-    @Override
-    public double compute() {
-        if (tp == null) return 0.0;
-        // Guard against zero denominator (no predicted positives for a class):
-        // replace 0 entries in (tp+fp) with 1 so that TP/1 = 0 precision for
-        // classes that were never predicted positive.
+    /**
+     * Returns the precision of each class, before any averaging is applied.
+     * Guard against zero denominator (no predicted positives for a class):
+     * replace 0 entries in (tp+fp) with 1 so that TP/1 = 0 precision for
+     * classes that were never predicted positive.
+     * @return the per-class precision.
+     */
+    Tensor score() {
         Tensor denom = tp.add(fp);
         Tensor ones  = denom.newOnes(denom.shape());
         Tensor safe  = Tensor.where(denom.gt(0), denom, ones);
-        Tensor precision = tp.div(safe);
+        return tp.div(safe);
+    }
+
+    @Override
+    public double compute() {
+        if (tp == null) return 0.0;
+        Tensor precision = score();
         if (strategy == Averaging.Macro) {
             precision = precision.mean();
         } else if (strategy == Averaging.Weighted) {
-            precision = precision.mul(size).sum().div(size.sum());
+            return Averaging.weighted(precision, size);
         }
         return precision.doubleValue();
     }

--- a/deep/src/main/java/smile/deep/metric/Recall.java
+++ b/deep/src/main/java/smile/deep/metric/Recall.java
@@ -115,25 +115,38 @@ public class Recall implements Metric {
         this.size.add_(size);
     }
 
+    /**
+     * Returns the recall of each class, before any averaging is applied.
+     * Guard against zero denominator: replace 0-count classes with 1
+     * so that TP/1 = 0 recall, avoiding NaN.
+     * @return the per-class recall.
+     */
+    Tensor score() {
+        Tensor ones     = size.newOnes(size.shape());
+        Tensor safeSize = Tensor.where(size.gt(0), size, ones);
+        return tp.div(safeSize);
+    }
+
     @Override
     public double compute() {
         if (tp == null) return 0.0;
         Tensor recall;
-        // Guard against zero denominator: replace 0-count classes with 1
-        // so that TP/1 = 0 recall, avoiding NaN.
-        Tensor ones     = size.newOnes(size.shape());
-        Tensor safeSize = Tensor.where(size.gt(0), size, ones);
-        if (tp.size(0) == 1) {
-            long positives = size.getLong(1);
-            recall = strategy == null ? tp.div(Math.max(1L, positives)) : tp.div(safeSize.sum());
+        if (strategy == null || strategy == Averaging.Micro) {
+            // Both reduce to a single ratio of true positives over the actual
+            // positives (binary) or over all the samples (micro). The per-class
+            // guard of score() must not be applied here: counting an empty class
+            // as one sample would inflate the denominator and micro recall would
+            // no longer be equal to accuracy.
+            double positives = strategy == null ? size.getLong(1) : size.sum().doubleValue();
+            recall = tp.div(Math.max(1.0, positives));
         } else {
-            recall = tp.div(safeSize);
+            recall = score();
         }
 
         if (strategy == Averaging.Macro) {
             recall = recall.mean();
         } else if (strategy == Averaging.Weighted) {
-            recall = recall.mul(size).sum().div(size.sum());
+            return Averaging.weighted(recall, size);
         }
         return recall.doubleValue();
     }

--- a/deep/src/test/java/smile/deep/metric/MetricTest.java
+++ b/deep/src/test/java/smile/deep/metric/MetricTest.java
@@ -546,4 +546,154 @@ public class MetricTest {
                 "Weighted recall should equal accuracy for perfect predictions");
         output.close(); tgt.close();
     }
+
+    // -----------------------------------------------------------------------
+    // Macro/weighted F1 with unequal per-class scores
+    //
+    // Confusion matrix (rows = truth, columns = prediction):
+    //
+    //          pred 0  pred 1  pred 2   support
+    // true 0        4       6       0        10
+    // true 1        0       2       0         2
+    // true 2        0       0       3         3
+    //
+    // per-class precision = [4/4, 2/8, 3/3] = [1, 1/4,   1]
+    // per-class recall    = [4/10, 2/2, 3/3] = [2/5,  1,   1]
+    // per-class F1        = [4/7,  2/5,  1]
+    //
+    // macro F1    = (4/7 + 2/5 + 1) / 3           = 23/35  = 0.65714286
+    // weighted F1 = (10*4/7 + 2*2/5 + 3*1) / 15   = 111/175 = 0.63428571
+    //
+    // Averaging precision and recall first gives macro P = 3/4, macro R = 4/5
+    // and 2PR/(P+R) = 0.77419355, and weighted P = 9/10, weighted R = 3/5 and
+    // 2PR/(P+R) = 0.72 — neither is an F1 score of anything.
+    // -----------------------------------------------------------------------
+
+    /** Truth labels of the imbalanced three-class fixture above. */
+    private static final int[] IMBALANCED_TRUTH = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 2, 2};
+    /** Predictions of the imbalanced three-class fixture above. */
+    private static final int[] IMBALANCED_PRED  = {0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2};
+
+    @Test
+    public void testGivenUnequalPerClassScoresWhenComputingMacroF1ThenAveragesPerClassF1() {
+        Tensor output = logits(IMBALANCED_PRED, 3);
+        Tensor tgt    = target(IMBALANCED_TRUTH);
+        F1Score metric = new F1Score(Averaging.Macro);
+
+        metric.update(output, tgt);
+        assertEquals(23.0 / 35.0, metric.compute(), 1e-6);
+        output.close(); tgt.close();
+    }
+
+    @Test
+    public void testGivenUnequalPerClassScoresWhenComputingWeightedF1ThenAveragesPerClassF1() {
+        Tensor output = logits(IMBALANCED_PRED, 3);
+        Tensor tgt    = target(IMBALANCED_TRUTH);
+        F1Score metric = new F1Score(Averaging.Weighted);
+
+        metric.update(output, tgt);
+        assertEquals(111.0 / 175.0, metric.compute(), 1e-6);
+        output.close(); tgt.close();
+    }
+
+    @Test
+    public void testGivenUnequalPerClassScoresWhenComputingMacroF1ThenNotHarmonicMeanOfAverages() {
+        Tensor output = logits(IMBALANCED_PRED, 3);
+        Tensor tgt    = target(IMBALANCED_TRUTH);
+
+        F1Score   f1 = new F1Score(Averaging.Macro);
+        Precision p  = new Precision(Averaging.Macro);
+        Recall    r  = new Recall(Averaging.Macro);
+        f1.update(output, tgt);
+        p.update(output, tgt);
+        r.update(output, tgt);
+
+        double averaged = 2 * p.compute() * r.compute() / (p.compute() + r.compute());
+        assertEquals(0.7741935, averaged, 1e-6);
+        assertNotEquals(averaged, f1.compute(), 1e-3,
+                "macro F1 must average the per-class F1 scores, not combine the averaged precision and recall");
+        output.close(); tgt.close();
+    }
+
+    @Test
+    public void testGivenMultipleBatchesWhenComputingMacroF1ThenAveragesOverAccumulatedCounts() {
+        // Same 15 samples as above, split across two updates. The metric accumulates
+        // counts, so the result must match the single-batch value.
+        int[] truth1 = {0, 0, 0, 0, 0, 0, 0};
+        int[] pred1  = {0, 0, 0, 0, 1, 1, 1};
+        int[] truth2 = {0, 0, 0, 1, 1, 2, 2, 2};
+        int[] pred2  = {1, 1, 1, 1, 1, 2, 2, 2};
+
+        Tensor out1 = logits(pred1, 3); Tensor tgt1 = target(truth1);
+        Tensor out2 = logits(pred2, 3); Tensor tgt2 = target(truth2);
+
+        F1Score metric = new F1Score(Averaging.Macro);
+        metric.update(out1, tgt1);
+        metric.update(out2, tgt2);
+
+        assertEquals(23.0 / 35.0, metric.compute(), 1e-6);
+        out1.close(); tgt1.close(); out2.close(); tgt2.close();
+    }
+
+    // -----------------------------------------------------------------------
+    // Micro-averaging when a class has no instance in the batch
+    //
+    //          pred 0  pred 1  pred 2   support
+    // true 0        4       1       0         5
+    // true 1        1       4       0         5
+    // true 2        0       0       0         0
+    //
+    // 8 of 10 samples are correct, so accuracy, micro precision, micro recall
+    // and micro F1 are all 0.8. Class 2 has no instance; its per-class guard
+    // must not leak into the micro denominator.
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testGivenClassWithoutInstancesWhenComputingMicroRecallThenEqualsAccuracy() {
+        int[] truth = {0, 0, 0, 0, 0, 1, 1, 1, 1, 1};
+        int[] pred  = {0, 0, 0, 0, 1, 0, 1, 1, 1, 1};
+        Tensor output = logits(pred, 3); Tensor tgt = target(truth);
+
+        Accuracy acc  = new Accuracy();
+        Recall microR = new Recall(Averaging.Micro);
+        acc.update(output, tgt);
+        microR.update(output, tgt);
+
+        assertEquals(0.8, acc.compute(), 1e-6);
+        assertEquals(0.8, microR.compute(), 1e-6);
+        output.close(); tgt.close();
+    }
+
+    @Test
+    public void testGivenClassWithoutInstancesWhenComputingMicroF1ThenEqualsAccuracy() {
+        int[] truth = {0, 0, 0, 0, 0, 1, 1, 1, 1, 1};
+        int[] pred  = {0, 0, 0, 0, 1, 0, 1, 1, 1, 1};
+        Tensor output = logits(pred, 3); Tensor tgt = target(truth);
+
+        Precision microP = new Precision(Averaging.Micro);
+        F1Score   microF = new F1Score(Averaging.Micro);
+        microP.update(output, tgt);
+        microF.update(output, tgt);
+
+        assertEquals(0.8, microP.compute(), 1e-6);
+        assertEquals(0.8, microF.compute(), 1e-6);
+        output.close(); tgt.close();
+    }
+
+    @Test
+    public void testGivenWeightedMetricsWhenResetThenComputeReturnsZero() {
+        // reset() is called at the end of every epoch. Macro and micro already
+        // returned 0 for the empty state; weighted must not return NaN either.
+        Tensor output = logits(IMBALANCED_PRED, 3);
+        Tensor tgt    = target(IMBALANCED_TRUTH);
+
+        for (Metric metric : new Metric[]{new Precision(Averaging.Weighted),
+                                          new Recall(Averaging.Weighted),
+                                          new F1Score(Averaging.Weighted)}) {
+            metric.update(output, tgt);
+            metric.reset();
+            assertEquals(0.0, metric.compute(), 1e-9, metric.name());
+        }
+        output.close(); tgt.close();
+    }
 }


### PR DESCRIPTION
Follow-up to #874, as requested there.

`deep.metric.F1Score` had the same F-of-means defect that #874 fixed in `smile.validation.metric.FScore`. While auditing the rest of the package against scikit-learn I found two more variants of the same mistake — the reduction of an averaging strategy applied to the wrong quantity, or without the guard the other strategies have — so this fixes the class rather than the one method.

### 1. Macro and weighted F1 averaged the wrong thing

`F1Score.compute()` called `precision.compute()` and `recall.compute()`, which already reduce the per-class vector to a scalar, then took their harmonic mean. F1 is not linear in (P, R), so `F1(mean P, mean R)` is not the mean of the per-class F1 scores.

Confusion matrix (rows = truth, columns = prediction):

```
        pred 0  pred 1  pred 2   support
true 0       4       6       0        10
true 1       0       2       0         2
true 2       0       0       3         3
```

per-class precision = [1, 1/4, 1], recall = [2/5, 1, 1], F1 = [4/7, 2/5, 1]

|             | before     | correct              |
|-------------|------------|----------------------|
| macro F1    | 0.77419355 | 23/35 = 0.65714286   |
| weighted F1 | 0.72       | 111/175 = 0.63428571 |

### 2. Micro recall stopped equalling accuracy when a class is empty

`Recall.compute()` divided the micro score by `where(size > 0, size, 1).sum()`. That guard exists to keep the per-class recall of an empty class at 0 instead of NaN, but summing it makes every empty class add one phantom sample to the micro denominator. `Averaging.Micro`'s javadoc states that micro precision and recall equal accuracy, and `validation.metric.Recall` divides by `n`.

With 3 output classes, no instance of class 2 in the batch and 8 of 10 samples correct, micro recall was 8/11 = 0.72727275 and micro F1 was 16/21 = 0.76190478, against an accuracy of 0.8. Any mini-batch that happens to miss a rare class hits this.

### 3. Weighted metrics returned NaN after reset()

The weighted reduction `score.mul(size).sum().div(size.sum())` has no guard for the empty state, so `Precision`, `Recall` and `F1Score` all returned NaN after `reset()` — called at the end of every epoch, per the `Metric` javadoc. Macro and micro return 0 there, and there is already a test asserting that for macro F1.

### Changes

`Precision.score()` and `Recall.score()` expose the per-class score with the guard each already had, so `F1Score` can average the per-class F1 without duplicating them. `Averaging.weighted()` performs the support-weighted reduction once for the three metrics. `Recall.compute()` now branches on the strategy rather than on `tp.size(0)`.

### Verification

Differential run against scikit-learn 1.8.0 over 10 label sets (perfect, imbalanced 3-class 900/80/20, imbalanced 4-class, binary, never-predicted class, empty class, all-wrong, multi-batch, random 5-class, single-class truth), covering every metric and averaging strategy — 109 comparisons. 18 divergences before, none after, largest remaining difference 9e-08 in float32. Accuracy, all three precisions, macro/weighted recall and the binary metrics already agreed, so the audit closes the class.

7 new tests in `MetricTest`, every one of them failing before the change. `./gradlew :deep:test` goes from 391 tests / 0 failures to 398 / 0. The existing tests missed all three bugs because they only cover perfect predictions, binary classification, and micro averaging on batches where every class is present.
