### PR TITLE
Fix tail p-values collapsing to 0 in Gamma/GLM, and NegativeBinomial pmf overflow

### DIFF
--- a/base/src/main/java/smile/math/special/Gamma.java
+++ b/base/src/main/java/smile/math/special/Gamma.java
@@ -149,7 +149,7 @@ public class Gamma {
             igf = regularizedIncompleteGammaSeries(s, x);
         } else {
             // Continued fraction representation
-            igf = regularizedIncompleteGammaFraction(s, x);
+            igf = 1.0 - regularizedUpperIncompleteGammaFraction(s, x);
         }
 
         return igf;
@@ -159,7 +159,7 @@ public class Gamma {
      * Regularized Upper/Complementary Incomplete Gamma Function
      * Q(s,x) = 1 - P(s,x) = 1 - <i>&#8747;<sub><small>0</small></sub><sup><small>x</small></sup> e<sup>-t</sup> t<sup>(s-1)</sup> dt</i>
      * <p>
-     * Returns 0 when x = 0, and {@code Double.NaN} when x is NaN.
+     * Returns 1 when x = 0, and {@code Double.NaN} when x is NaN.
      *
      * @param s {@code s >= 0}
      * @param x {@code x >= 0}
@@ -187,7 +187,7 @@ public class Gamma {
             return 1.0 - regularizedIncompleteGammaSeries(s, x);
         } else {
             // Continued fraction representation
-            return 1.0 - regularizedIncompleteGammaFraction(s, x);
+            return regularizedUpperIncompleteGammaFraction(s, x);
         }
     }
 
@@ -228,18 +228,21 @@ public class Gamma {
     }
 
     /**
-     * Regularized Incomplete Gamma Function P(a,x) = <i><big>&#8747;</big><sub><small>0</small></sub><sup><small>x</small></sup> e<sup>-t</sup> t<sup>(a-1)</sup> dt</i>.
+     * Regularized Upper Incomplete Gamma Function Q(a,x) = <i><big>&#8747;</big><sub><small>x</small></sub><sup><small>&#8734;</small></sup> e<sup>-t</sup> t<sup>(a-1)</sup> dt</i>.
      * Continued Fraction representation of the function - valid for {@code x >= a + 1}.
      * This method follows the general procedure used in Numerical Recipes.
+     * <p>
+     * Q is returned rather than P = 1 - Q: for {@code x >= a + 1} Q is the small
+     * quantity, and forming it as 1 - P would round it to a multiple of
+     * 2<sup>-53</sup> and to exactly 0 below 2<sup>-54</sup>.
      */
-    private static double regularizedIncompleteGammaFraction(double a, double x) {
+    private static double regularizedUpperIncompleteGammaFraction(double a, double x) {
         if (a < 0.0 || x < 0.0 || x < a + 1) {
             throw new IllegalArgumentException(String.format("Invalid a = %f, x = %f", a, x));
         }
 
         int i = 0;
         double ii;
-        double igf;
         boolean check = true;
 
         double loggamma = lgamma(a);
@@ -271,11 +274,10 @@ public class Gamma {
             }
             if (i >= INCOMPLETE_GAMMA_MAX_ITERATIONS) {
                 check = false;
-                logger.error("Gamma.regularizedIncompleteGammaFraction: Maximum number of iterations was exceeded");
+                logger.error("Gamma.regularizedUpperIncompleteGammaFraction: Maximum number of iterations was exceeded");
             }
         }
-        igf = 1.0 - exp(-x + a * log(x) - loggamma) * prod;
-        return igf;
+        return exp(-x + a * log(x) - loggamma) * prod;
     }
 
     /**

--- a/base/src/main/java/smile/stat/distribution/NegativeBinomialDistribution.java
+++ b/base/src/main/java/smile/stat/distribution/NegativeBinomialDistribution.java
@@ -18,10 +18,8 @@ package smile.stat.distribution;
 
 import java.io.Serial;
 import smile.math.MathEx;
-import static smile.math.MathEx.factorial;
 import static smile.math.MathEx.lfactorial;
 import static smile.math.special.Beta.regularizedIncompleteBetaFunction;
-import static smile.math.special.Gamma.gamma;
 import static smile.math.special.Gamma.lgamma;
 
 /**
@@ -153,7 +151,7 @@ public class NegativeBinomialDistribution extends DiscreteDistribution {
         if (k < 0) {
             return 0.0;
         } else {
-            return gamma(r + k) / (factorial(k) * gamma(r)) * Math.pow(p, r) * Math.pow(1 - p, k);
+            return Math.exp(logp(k));
         }
     }
 

--- a/base/src/test/java/smile/math/special/GammaTest.java
+++ b/base/src/test/java/smile/math/special/GammaTest.java
@@ -286,5 +286,41 @@ public class GammaTest {
         // ψ(10) ≈ 2.25175...
         assertEquals(2.251753, Gamma.digamma(10.0), 1E-6);
     }
+
+    @Test
+    public void testUpperIncompleteGammaFarTail() {
+        System.out.println("Q(s,x) far tail");
+        // Reference values from mpmath at 120 digits.
+        double[][] cases = {
+                { 0.5,  35.0, 5.930445850082487E-17},
+                { 1.0,  37.0, 8.533047625744066E-17},
+                { 2.0,  40.0, 1.7418252446695514E-16},
+                {10.0,  60.0, 2.85150775555202E-16},
+                { 0.5,  50.0, 1.523970604832105E-23},
+                { 1.0,  50.0, 1.9287498479639178E-22},
+                { 5.0,  50.0, 5.4497019829205295E-17},
+                { 1.5,  50.0, 1.554159431389605E-21},
+                { 1.0, 100.0, 3.720075976020836E-44},
+                {50.0, 200.0, 1.6927979958857087E-37},
+                { 0.5, 500.0, 1.7958327848007262E-219},
+        };
+        for (double[] c : cases) {
+            double q = Gamma.regularizedUpperIncompleteGamma(c[0], c[1]);
+            assertEquals(c[2], q, Math.abs(c[2]) * 1E-6,
+                    String.format("Q(%.1f, %.1f) = %s", c[0], c[1], q));
+        }
+    }
+
+    @Test
+    public void testUpperIncompleteGammaStrictlyDecreasing() {
+        System.out.println("Q(s,x) strictly decreasing into the tail");
+        double prev = Double.MAX_VALUE;
+        for (double x = 30.0; x <= 300.0; x += 5.0) {
+            double q = Gamma.regularizedUpperIncompleteGamma(2.0, x);
+            assertTrue(q > 0.0, "Q(2, " + x + ") = " + q);
+            assertTrue(q < prev, "Q(2, " + x + ") = " + q + " is not below Q(2, " + (x - 5.0) + ")");
+            prev = q;
+        }
+    }
 }
 

--- a/base/src/test/java/smile/stat/distribution/NegativeBinomialDistributionTest.java
+++ b/base/src/test/java/smile/stat/distribution/NegativeBinomialDistributionTest.java
@@ -164,5 +164,27 @@ public class NegativeBinomialDistributionTest {
         assertEquals(3.0, est.r, 0.5);
         assertEquals(0.3, est.p, 0.05);
     }
+
+    /**
+     * p(k) used to overflow past k = 161. Mean is 90 and sd is 30 here, so those
+     * are ordinary values. Reference values from mpmath at 120 digits.
+     */
+    @Test
+    public void testPmfLargeK() {
+        System.out.println("p(k) for large k");
+        NegativeBinomialDistribution instance = new NegativeBinomialDistribution(10, 0.1);
+        assertEquals(0.0011318291241213503,  instance.p(161), 1E-15);
+        assertEquals(0.0010752376679152827,  instance.p(162), 1E-15);
+        assertEquals(0.0007442757647287806,  instance.p(169), 1E-15);
+        assertEquals(1.1790936128864348E-7,  instance.p(300), 1E-16);
+
+        double sum = 0.0;
+        for (int k = 0; k <= 400; k++) {
+            assertTrue(Double.isFinite(instance.p(k)), "p(" + k + ") = " + instance.p(k));
+            sum += instance.p(k);
+        }
+        // The pmf sum has to agree with cdf(), which goes through the incomplete beta.
+        assertEquals(instance.cdf(400), sum, 1E-9);
+    }
 }
 

--- a/base/src/test/java/smile/stat/distribution/PoissonDistributionTest.java
+++ b/base/src/test/java/smile/stat/distribution/PoissonDistributionTest.java
@@ -171,6 +171,20 @@ public class PoissonDistributionTest {
     }
 
     /**
+     * cdf() is the upper incomplete gamma, whose far tail used to collapse to 0.
+     * Reference values from mpmath at 120 digits.
+     */
+    @Test
+    public void testCdfFarTail() {
+        System.out.println("cdf far tail");
+        PoissonDistribution instance = new PoissonDistribution(500);
+        assertEquals(1.9241648854434787E-14, instance.cdf(340), 1E-20);
+        assertEquals(4.336865760332492E-18,  instance.cdf(320), 1E-24);
+        assertEquals(2.8361496727739246E-22, instance.cdf(300), 1E-28);
+        assertEquals(2.4265925398339247E-35, instance.cdf(250), 1E-41);
+    }
+
+    /**
      * Test of quantile method, of class Poisson.
      */
     @Test

--- a/base/src/test/java/smile/stat/hypothesis/ChiSqTestTest.java
+++ b/base/src/test/java/smile/stat/hypothesis/ChiSqTestTest.java
@@ -101,4 +101,27 @@ public class ChiSqTestTest {
         assertEquals(5.179, test.chisq(), 1E-3);
         assertEquals(0.2695, test.pvalue(), 1E-4);
     }
+
+    /**
+     * All three tests share the upper incomplete gamma, whose far tail used to
+     * collapse to 0. Reference p-values from mpmath at 120 digits.
+     */
+    @Test
+    public void testFarTailPValue() {
+        System.out.println("far tail p-value");
+        ChiSqTest one = ChiSqTest.test(new int[]{150, 50, 150, 50}, new double[]{0.25, 0.25, 0.25, 0.25});
+        assertEquals(100.0, one.chisq(), 1E-9);
+        assertEquals(3, one.df(), 1E-10);
+        assertEquals(1.554159431389605E-21, one.pvalue(), 1E-27);
+
+        ChiSqTest two = ChiSqTest.test(new int[]{100, 10, 100, 10}, new int[]{10, 100, 10, 100});
+        assertEquals(294.5455, two.chisq(), 1E-4);
+        assertEquals(3, two.df(), 1E-10);
+        assertEquals(1.507476167666212E-63, two.pvalue(), 1E-69);
+
+        ChiSqTest table = ChiSqTest.test(new int[][]{{100, 10}, {10, 100}});
+        assertEquals(144.0182, table.chisq(), 1E-4);
+        assertEquals(1, table.df(), 1E-10);
+        assertEquals(3.520591654384769E-33, table.pvalue(), 1E-39);
+    }
 }

--- a/core/src/main/java/smile/regression/GLM.java
+++ b/core/src/main/java/smile/regression/GLM.java
@@ -452,7 +452,7 @@ public class GLM implements DataFrameRegression, Serializable {
             ztest[i][0] = beta.get(i);
             ztest[i][1] = Math.sqrt(inv.get(i, i));
             ztest[i][2] = ztest[i][0] / ztest[i][1];
-            ztest[i][3] = 2.0 - Erf.erfc(-0.707106781186547524 * Math.abs(ztest[i][2]));
+            ztest[i][3] = Erf.erfc(0.707106781186547524 * Math.abs(ztest[i][2]));
         }
 
         return new GLM(formula, schema, model, beta.toArray(new double[0]), model.logLikelihood(y, mu),

--- a/core/src/test/java/smile/regression/GLMTest.java
+++ b/core/src/test/java/smile/regression/GLMTest.java
@@ -25,6 +25,7 @@ import smile.data.type.DataTypes;
 import smile.data.type.StructField;
 import smile.data.type.StructType;
 import smile.math.MathEx;
+import smile.math.special.Erf;
 import smile.regression.glm.*;
 import smile.io.Read;
 import smile.io.Write;
@@ -82,6 +83,14 @@ public class GLMTest {
             for (int j = 0; j < 4; j++) {
                 assertEquals(ztest[i][j], model.ztest()[i][j], 1E-4);
             }
+        }
+
+        // The two significant coefficients round to 0.00000 above, but their
+        // p-values are not 0. References from mpmath at 120 digits.
+        assertEquals(4.995317351262854E-108, model.ztest()[0][3], 1E-114);
+        assertEquals(4.331279226426007E-135, model.ztest()[2][3], 1E-141);
+        for (double[] row : model.ztest()) {
+            assertEquals(Erf.erfc(Math.abs(row[2]) / Math.sqrt(2.0)), row[3], Math.abs(row[3]) * 1E-9);
         }
 
         java.nio.file.Path temp = Write.object(model);

--- a/core/src/test/java/smile/timeseries/BoxTestTest.java
+++ b/core/src/test/java/smile/timeseries/BoxTestTest.java
@@ -71,6 +71,28 @@ public class BoxTestTest {
         assertEquals(0.1074, box.pvalue, 1E-4);
     }
 
+    /**
+     * Squared log returns cluster strongly, so both statistics land deep in the
+     * upper incomplete gamma tail, which used to collapse to 0.
+     * Reference p-values from mpmath at 120 digits.
+     */
+    @Test
+    public void testFarTailPValue() {
+        System.out.println("far tail p-value");
+        double[] squared = new double[logPriceDiff.length];
+        for (int i = 0; i < squared.length; i++) {
+            squared[i] = logPriceDiff[i] * logPriceDiff[i];
+        }
+
+        BoxTest pierce = BoxTest.pierce(squared, 5);
+        assertEquals(298.9329, pierce.q, 1E-4);
+        assertEquals(1.6985648788603546E-62, pierce.pvalue, 1E-68);
+
+        BoxTest ljung = BoxTest.ljung(squared, 5);
+        assertEquals(299.6063, ljung.q, 1E-4);
+        assertEquals(1.2170258639750189E-62, ljung.pvalue, 1E-68);
+    }
+
     @Test
     public void givenInvalidLag_whenRunningPortmanteauTests_thenThrowIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, () -> BoxTest.pierce(logPriceDiff, 0));


### PR DESCRIPTION
`Gamma.regularizedUpperIncompleteGamma` returns `1 - (1 - Q)` on the `x >= s + 1` branch: the continued fraction evaluates `Q`, converts it to `P`, and the caller converts it back. The round trip through a number near 1 quantises `Q` to multiples of 2^-53 and floors it at exactly 0 once `Q < 2^-54`.

```
ChiSqTest.test({150,50,150,50}, {.25,.25,.25,.25})   chisq=100, df=3
    pvalue = 0.0                            (true 1.554e-21)
PoissonDistribution(500).cdf(300) = 0.0     (true 2.836e-22)
BoxTest.ljung(squared bitcoin log returns, 5), q=299.6
    pvalue = 0.0                            (true 1.217e-62)
```

That covers the three `ChiSqTest.test` overloads, both `BoxTest` statistics and `PoissonDistribution.cdf`. The fix returns the fraction's own `Q` and derives `P = 1 - Q`, as `gammq`/`gammp` do in Numerical Recipes; `P` is unchanged bit for bit.

A differential over the rest of the family against mpmath (3339 points across `Gamma`, `Beta`, `Erf` and the CDFs and tests built on them) found two more sites:

- `GLM.ztest()` built the two-sided p-value as `2.0 - Erf.erfc(-|z|/sqrt(2))`, i.e. `2 - (2 - erfc)`, so it floors at 0 for `|z|` over about 8.3. `GLMTest.testDefault` pins those two as `0.00000` at 1e-4; they are 5.0e-108 and 4.3e-135.
- `NegativeBinomialDistribution.p(k)` returns `Infinity` from k=162 and `NaN` from k=169 — only 2.4 sigma out at `r=10, p=0.1`. `logp` right below it already had the stable lgamma form.

`Beta.regularizedIncompleteBetaFunction`, `Erf.erfc`, `KSTest.qks`, `TDistribution.cdf`/`cdf2tailed` and the t-, F- and correlation tests were checked and are correct — they all evaluate the small quantity directly, which is what `Gamma` now does too. 283 of the 3339 points were wrong before, 0 after.

Tests added to the six affected test classes; all 7 fail on master. `:base:test` goes 2600 -> 2605 tests and `:core:test` 1312 -> 1313, with an identical set of pre-existing failures either way (native BLAS and ONNX on my machine).
