### PR TITLE
Fix MatthewsCorrelation int overflow and zero-denominator NaN

### DIFF
--- a/core/src/main/java/smile/validation/metric/MatthewsCorrelation.java
+++ b/core/src/main/java/smile/validation/metric/MatthewsCorrelation.java
@@ -67,8 +67,14 @@ public class MatthewsCorrelation implements ClassificationMetric {
         int fp = matrix[0][1];
         int fn = matrix[1][0];
 
-        int numerator = (tp * tn - fp * fn);
+        // Compute in long to avoid int overflow of tp * tn on large samples (cf. AUC).
+        long numerator = (long) tp * tn - (long) fp * fn;
         double denominator = Math.sqrt(tp + fp) * Math.sqrt(tp + fn) * Math.sqrt(tn + fp) * Math.sqrt(tn + fn);
+
+        // A zero marginal makes the denominator 0; MCC is 0 by convention.
+        if (denominator == 0.0) {
+            return 0.0;
+        }
 
         return numerator / denominator;
     }

--- a/core/src/test/java/smile/validation/metric/MatthewsCorrelationTest.java
+++ b/core/src/test/java/smile/validation/metric/MatthewsCorrelationTest.java
@@ -74,4 +74,52 @@ public class MatthewsCorrelationTest {
         assertEquals(expResult, result, 1E-5);
     }
 
+    /** Builds truth/prediction arrays realizing a 2x2 confusion (tp, tn, fp, fn). */
+    private static int[][] confusion(int tp, int tn, int fp, int fn) {
+        int n = tp + tn + fp + fn;
+        int[] truth = new int[n], prediction = new int[n];
+        int i = 0;
+        for (int k = 0; k < tp; k++) { truth[i] = 1; prediction[i] = 1; i++; }
+        for (int k = 0; k < tn; k++) { truth[i] = 0; prediction[i] = 0; i++; }
+        for (int k = 0; k < fp; k++) { truth[i] = 0; prediction[i] = 1; i++; }
+        for (int k = 0; k < fn; k++) { truth[i] = 1; prediction[i] = 0; i++; }
+        return new int[][]{truth, prediction};
+    }
+
+    /**
+     * A 90%-accurate classifier on 110k samples: tp*tn = 2.5e9 overflows int.
+     * The numerator must be computed in long, else the sign flips (-0.6016).
+     * sklearn.metrics.matthews_corrcoef reports 9/11 = 0.8181818181818182.
+     */
+    @Test
+    public void givenLargeSample_whenMCCComputed_thenNoIntOverflow() {
+        int[][] c = confusion(50000, 50000, 5000, 5000);
+        assertEquals(0.8181818181818182, MatthewsCorrelation.of(c[0], c[1]), 1E-9);
+    }
+
+    /**
+     * A constant predictor zeroes a confusion marginal, so the denominator is 0.
+     * MCC is 0 by convention (matches sklearn) rather than 0/0 = NaN.
+     */
+    @Test
+    public void givenConstantPredictor_whenMCCComputed_thenReturnsZero() {
+        int[] truth      = {1, 1, 0, 0, 1, 0};
+        int[] prediction = {0, 0, 0, 0, 0, 0};
+        assertEquals(0.0, MatthewsCorrelation.of(truth, prediction), 1E-10);
+    }
+
+    /** MCC is a correlation coefficient, so it must stay within [-1, 1]. */
+    @Test
+    public void givenVariousConfusions_whenMCCComputed_thenInUnitInterval() {
+        int[][] cases = {
+            {30, 60, 5, 5}, {90, 5, 3, 2}, {2, 2, 2, 2},
+            {50000, 50000, 5000, 5000}, {1, 100, 100, 1}, {0, 4, 0, 2}
+        };
+        for (int[] tc : cases) {
+            int[][] c = confusion(tc[0], tc[1], tc[2], tc[3]);
+            double mcc = MatthewsCorrelation.of(c[0], c[1]);
+            assertTrue(mcc >= -1.0 && mcc <= 1.0, "MCC out of [-1,1]: " + mcc);
+        }
+    }
+
 }


### PR DESCRIPTION
`MatthewsCorrelation.of` has two silent numeric defects.

**Int overflow flips the sign.** `tp * tn - fp * fn` is computed as `int` and wraps at 2^31. A 90%-accurate classifier on 110k samples (tp=tn=50000, fp=fn=5000) reports -0.6016 instead of +0.8182 — a wrong-sign metric, no exception. `AUC.of` in this same package already guards this exact case ("*for large sample size, overflow may happen for pos * neg. switch to double to prevent it.*"), but the guard was never carried over here. Now computed in `long`.

**Zero marginal returns NaN.** A constant predictor zeroes a confusion marginal, so the denominator is 0 and the method returns 0/0 = NaN. It now returns 0, matching scikit-learn's `matthews_corrcoef` and the standard convention.

Expected values come from `sklearn.metrics.matthews_corrcoef`; the currently-correct cases are bit-identical after the change (`long` and `int` agree there). Added tests cover the overflow sign-flip, the degenerate predictor, and the MCC in [-1, 1] invariant. The rest of `validation/metric` was checked for the same int-product overflow and is clean (AUC/AMI already accumulate in double).
