### PR TITLE
Fix int overflow in CorTest.spearman and CorTest.kendall for large samples

### DIFF
--- a/base/src/main/java/smile/stat/hypothesis/CorTest.java
+++ b/base/src/main/java/smile/stat/hypothesis/CorTest.java
@@ -166,7 +166,8 @@ public record CorTest(String method, double cor, double t, double df, double pva
             d += MathEx.pow2(wksp1[j] - wksp2[j]);
         }
 
-        double en3n = n * n * n - n;
+        // for large n, n * n * n overflows int before widening. promote first.
+        double en3n = (double) n * n * n - n;
         double fac = (1.0 - sf / en3n) * (1.0 - sg / en3n);
         double rs = (1.0 - (6.0 / en3n) * (d + (sf + sg) / 12.0)) / Math.sqrt(fac);
         fac = (rs + 1.0) * (1.0 - rs);
@@ -197,7 +198,9 @@ public record CorTest(String method, double cor, double t, double df, double pva
             throw new IllegalArgumentException("Input vectors have different size");
         }
 
-        int is = 0, n2 = 0, n1 = 0, n = x.length;
+        // pair counters reach n(n-1)/2, overflowing int for large n. use long.
+        long is = 0, n2 = 0, n1 = 0;
+        int n = x.length;
         double aa, a2, a1;
         for (int j = 0; j < n - 1; j++) {
             for (int k = j + 1; k < n; k++) {

--- a/base/src/test/java/smile/stat/hypothesis/CorTestTest.java
+++ b/base/src/test/java/smile/stat/hypothesis/CorTestTest.java
@@ -87,4 +87,47 @@ public class CorTestTest {
         assertEquals(0.4444444, test.cor(), 1E-7);
         assertEquals(0.0953, test.pvalue(), 1E-4);
     }
+
+    /**
+     * Test of spearman on a large sample. The n<sup>3</sup>-n rank
+     * normalization must be evaluated in double; computed in int it
+     * overflows for n >= 1291, pushing the coefficient outside [-1, 1].
+     */
+    @Test
+    public void testSpearmanLargeSample() {
+        System.out.println("spearman large sample");
+        // Strictly anti-correlated ranks (no ties): true Spearman rho is -1.
+        for (int n : new int[]{1290, 1291, 2000}) {
+            double[] x = new double[n];
+            double[] y = new double[n];
+            for (int i = 0; i < n; i++) {
+                x[i] = i;
+                y[i] = n - 1 - i;
+            }
+            double rho = CorTest.spearman(x, y).cor();
+            assertTrue(rho >= -1.0 && rho <= 1.0, "rho out of range at n=" + n + ": " + rho);
+            assertEquals(-1.0, rho, 1E-10, "n=" + n);
+        }
+    }
+
+    /**
+     * Test of kendall on a large sample. The concordant/discordant pair
+     * counters reach n(n-1)/2 and must be long; computed in int they
+     * overflow for n >= 65537, yielding NaN from the root of a negative count.
+     */
+    @Test
+    public void testKendallLargeSample() {
+        System.out.println("kendall large sample");
+        // Perfectly concordant ranks (no ties): true Kendall tau is +1.
+        int n = 65537;
+        double[] x = new double[n];
+        double[] y = new double[n];
+        for (int i = 0; i < n; i++) {
+            x[i] = i;
+            y[i] = i;
+        }
+        double tau = CorTest.kendall(x, y).cor();
+        assertTrue(tau >= -1.0 && tau <= 1.0, "tau out of range: " + tau);
+        assertEquals(1.0, tau, 1E-10);
+    }
 }


### PR DESCRIPTION
Two int-overflow bugs in `CorTest` corrupt the correlation coefficient on ordinary-sized inputs.

**Spearman.** `CorTest.spearman` computes the rank normalization as

```java
double en3n = n * n * n - n;
```

`n` is `int`, so `n * n * n` is evaluated in 32-bit arithmetic and overflows before the widening to `double`. For n >= 1291 (1291^3 = 2,151,683,880 > Integer.MAX_VALUE) `en3n` wraps negative and the returned coefficient is garbage — it even leaves the mathematically required range [-1, 1]:

```
n=1000  rho = -1.0        (correct, no overflow)
n=1291  rho =  3.0078...  (should be -1.0)
n=2000  rho = 28.12...    (should be -1.0)
```

(x = 0..n-1, y reversed: strictly anti-correlated ranks, true Spearman rho = -1.) Fix: widen the first operand so the whole product promotes, `(double) n * n * n - n`. Note `(double)(n * n * n)` would not help — the int product still overflows before the cast.

**Kendall.** `CorTest.kendall` accumulates the concordant/discordant and tie counters `is`, `n1`, `n2` as `int`. They reach n(n-1)/2, overflowing for n >= 65537, after which `tau = is / (sqrt(n1) * sqrt(n2))` takes the square root of a wrapped-negative count and returns `NaN` (true tau = 1 for a perfectly concordant input). Widened to `long`.

This is the same widen-before-you-multiply issue already guarded in `AUC.of` ("switch to double to prevent it"); the pattern just wasn't carried over to `CorTest`.

Verified against scipy (`spearmanr` / `kendalltau`, exact closed form) and the oracle-free invariant that a correlation coefficient must lie in [-1, 1]. Added `testSpearmanLargeSample` (n = 1290/1291/2000) and `testKendallLargeSample` (n = 65537); both fail on master and pass with the fix. The existing small-sample tests are unchanged and stay bit-identical.
