### PR TITLE
Studio: add null safety and fix `evalMagic` in code cells

### DIFF
--- a/studio/src/main/java/smile/studio/cli/Intent.java
+++ b/studio/src/main/java/smile/studio/cli/Intent.java
@@ -155,7 +155,10 @@ public class Intent extends JPanel {
     private JComboBox<String> initEffortComboBox(AgentCLI cli) {
         ArrayList<String> effortLevels =new ArrayList<>();
         effortLevels.add(LLM.DEFAULT_REASONING_EFFORT);
-        cli.agent().llm().ifPresent(model -> effortLevels.addAll(model.reasoningEffortLevels()));
+
+        if (cli.agent() != null) {
+            cli.agent().llm().ifPresent(model -> effortLevels.addAll(model.reasoningEffortLevels()));
+        }
 
         var levels = effortLevels.toArray(new String[0]);
         var effortComboBox = new JComboBox<>(levels);

--- a/studio/src/main/java/smile/studio/kernel/JavaKernel.java
+++ b/studio/src/main/java/smile/studio/kernel/JavaKernel.java
@@ -120,16 +120,16 @@ public class JavaKernel extends Kernel<SnippetEvent> {
 
     @Override
     public boolean eval(String code, List<Object> values) {
+        for (String line : code.split("\\r?\\n")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("//!")) {
+                evalMagic(trimmed.substring(3));
+            }
+        }
+
         SourceCodeAnalysis.CompletionInfo info = sourceAnalyzer.analyzeCompletion(code);
         while (info.completeness().isComplete()) {
             String source = info.source();
-            String[] lines = source.split("\\r?\\n");
-            for (String line : lines) {
-                line = line.trim();
-                if (line.startsWith("//!")) {
-                    evalMagic(line.substring(3));
-                }
-            }
 
             List<SnippetEvent> events = jshell.eval(source);
             process(events);


### PR DESCRIPTION
### Description
- **Bugfix / Guard:** Add `cli.agent() != null` check when AI-agents is inactive or disconnected.
- **Fix:** Move `evalMagic` parsing forward to prevent `SourceCodeAnalysis.CompletionInfo` from stripping `//!` commands as comments.