### PR TITLE
revert syncCaretUpdatePolicy in ThemedTextArea

### DIFF
--- a/studio/src/main/java/smile/studio/text/ThemedTextArea.java
+++ b/studio/src/main/java/smile/studio/text/ThemedTextArea.java
@@ -87,7 +87,6 @@ public class ThemedTextArea extends RSyntaxTextArea {
         };
         caret.setBlinkRate(getCaret().getBlinkRate());
         setCaret(caret);
-        syncCaretUpdatePolicy();
 
         applyTheme();
         // Listen for global Look and Feel changes
@@ -130,20 +129,6 @@ public class ThemedTextArea extends RSyntaxTextArea {
             if (IDEA_THEME != null) IDEA_THEME.apply(this);
         }
         setFont(Monospaced.getFont());
-    }
-
-    @Override
-    public void setEditable(boolean editable) {
-        super.setEditable(editable);
-        syncCaretUpdatePolicy();
-    }
-
-    private void syncCaretUpdatePolicy() {
-        if (getCaret() instanceof javax.swing.text.DefaultCaret caret) {
-            caret.setUpdatePolicy(isEditable()
-                    ? javax.swing.text.DefaultCaret.UPDATE_WHEN_ON_EDT
-                    : javax.swing.text.DefaultCaret.NEVER_UPDATE);
-        }
     }
 
     /**


### PR DESCRIPTION
### Description

This PR reverts the `syncCaretUpdatePolicy()` behavior introduced in the previous change to restore prior caret update semantics in `ThemedTextArea`. The revert is scoped to caret update-policy wiring only and leaves the rest of the text area theming/caret behavior intact.

- **Scope**
    - Removed the `syncCaretUpdatePolicy();` call from `initTheme()`.
    - Removed the `setEditable(boolean editable)` override that only delegated to `syncCaretUpdatePolicy()`.
    - Removed the `syncCaretUpdatePolicy()` helper method.
- **Resulting behavior**
    - Caret visibility customization remains.
    - Theme/font application paths remain unchanged.
    - Caret update policy is no longer forced between `UPDATE_WHEN_ON_EDT` and `NEVER_UPDATE`.