### PR TITLE
feat: add OrcaRouter as a named AI provider in SMILE Studio

### DIFF
--- a/studio/README.md
+++ b/studio/README.md
@@ -561,6 +561,7 @@ Open via **File > Settings…**. Choose an AI service provider from the drop-dow
 | **Anthropic** | Claude models; set API key, optional base URL, model |
 | **Google Gemini** | Gemini models via native API; set API key, model |
 | **Google Vertex AI** | Gemini via Vertex; set API key, base URL, model |
+| **OrcaRouter** | OpenAI-compatible AI gateway; set API key, base URL (defaults to `https://api.orcarouter.ai/v1`), model |
 
 All fields (API key, base URL, model) are stored in Java `Preferences` (OS keychain / registry). API keys set in Settings take precedence over environment variables.
 

--- a/studio/src/main/java/smile/studio/SettingsDialog.java
+++ b/studio/src/main/java/smile/studio/SettingsDialog.java
@@ -40,9 +40,10 @@ public class SettingsDialog extends JDialog implements ActionListener {
     private static final String MODEL = "Model";
     private static final String[] UI_THEMES = {"Light", "Dark"};
     // Interactions API is not yet supported on Vertex
-    private static final String[] aiServiceOptions = {"OpenAI", "Azure OpenAI", "Anthropic", "Google Gemini", "Google Gemini Enterprise", "Chat Completions Compatible"};
-    private static final String[] aiServiceKeys = {"openai", "azureOpenAI", "anthropic", "googleGemini", "googleEnterprise", "chatCompletions"};
+    private static final String[] aiServiceOptions = {"OpenAI", "Azure OpenAI", "Anthropic", "Google Gemini", "Google Gemini Enterprise", "OrcaRouter", "Chat Completions Compatible"};
+    private static final String[] aiServiceKeys = {"openai", "azureOpenAI", "anthropic", "googleGemini", "googleEnterprise", "orcarouter", "chatCompletions"};
     private static final String[] openaiModels = {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.4-mini"};
+    private static final String[] orcaRouterModels = {"orcarouter/fusion-mini", "orcarouter/fusion-flash", "orcarouter/fusion", "orcarouter/free"};
     private static final String[] anthropicModels = {"claude-fable-5", "claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5"};
     private static final String[] geminiModels = {"gemini-3.5-flash", "gemini-3.1-pro-preview", "gemini-3.1-flash-lite"};
     private static final String[] otherModels = {"llama3.2", "qwen3.5", "minimax-m2.7", "kimi-k2.6", "deepseek-r1"};
@@ -156,7 +157,7 @@ public class SettingsDialog extends JDialog implements ActionListener {
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 1.0;
         JTextField baseUrlField = new JTextField(25);
-        baseUrlField.setText(prefs.get(service + "BaseUrl", ""));
+        baseUrlField.setText(prefs.get(service + "BaseUrl", service.equals("orcarouter") ? "https://api.orcarouter.ai/v1" : ""));
         baseUrlFields.put(service, baseUrlField);
         card.add(baseUrlField, gbc);
 
@@ -175,6 +176,7 @@ public class SettingsDialog extends JDialog implements ActionListener {
             case "openai", "azureOpenAI" -> new JComboBox<>(openaiModels);
             case "anthropic" -> new JComboBox<>(anthropicModels);
             case "googleGemini", "googleVertexAI" -> new JComboBox<>(geminiModels);
+            case "orcarouter" -> new JComboBox<>(orcaRouterModels);
             case "chatCompletions" -> new JComboBox<>(otherModels);
             default -> new JComboBox<>();
         };

--- a/studio/src/main/java/smile/studio/SmileStudio.java
+++ b/studio/src/main/java/smile/studio/SmileStudio.java
@@ -280,6 +280,18 @@ public class SmileStudio extends JFrame implements SearchListener {
                         prefs.get("azureOpenAIBaseUrl", ""),
                         prefs.get("azureOpenAIModel", "gpt-5.5"));
 
+                // OrcaRouter is an OpenAI-compatible gateway, so we reuse the
+                // OpenAI client with the gateway's base URL and a routing model.
+                case "OrcaRouter" -> {
+                    var openai = new OpenAI(prefs.get("orcarouterModel", "orcarouter/fusion-mini"));
+                    var apiKey = prefs.get("orcarouterApiKey", "");
+                    if (!apiKey.isBlank()) {
+                        openai.withApiKey(apiKey);
+                    }
+                    openai.withBaseUrl(prefs.get("orcarouterBaseUrl", "https://api.orcarouter.ai/v1"));
+                    yield openai;
+                }
+
                 // Don't call withApiKey or withBaseUrl for Anthropic and Gemini client.
                 // As they read from system properties directly, calling withApiKey will
                 // cause errors.


### PR DESCRIPTION
Adding [OrcaRouter](https://www.orcarouter.ai) as a named AI provider in SMILE Studio means Studio users get the gateway's full stack directly from **File > Settings > AI Service**, instead of treating it as an anonymous "Chat Completions Compatible" base URL.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

The change mirrors the existing **OpenAI** entry in `SettingsDialog` and `SmileStudio.createLLM()`. OrcaRouter speaks the OpenAI Chat Completions protocol, so it reuses the `OpenAI` client pointed at `https://api.orcarouter.ai/v1` with an `orcarouter/*` routing model. The Settings dialog prefills that base URL and suggests `orcarouter/fusion-mini`, `orcarouter/fusion-flash`, `orcarouter/fusion`, and `orcarouter/free` as model choices.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

**Files changed**
- `studio/src/main/java/smile/studio/SettingsDialog.java` — new `OrcaRouter` service option, key, base URL default, and model suggestions
- `studio/src/main/java/smile/studio/SmileStudio.java` — new `case "OrcaRouter"` in `createLLM()`, mirroring the `OpenAI` wiring
- `studio/README.md` — provider row in the Settings table

**Verification**
- The full studio module compiles cleanly against the release dependency set.
- Live-tested the new provider path (`new OpenAI("orcarouter/fusion-mini").withApiKey(...).withBaseUrl("https://api.orcarouter.ai/v1")`) with a real chat completion through the OrcaRouter endpoint — returned a valid response.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
